### PR TITLE
Feature/single update application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 + added properties to CoNLLImporter to drop import of ordering and to qualify annotations with a separate name
 + simplified implementation of merge checker
 + merge checker always finishes and lists all misaligned documents
++ apply single combined update after imports are finished to avoid multiple calls to `apply_update`

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -321,12 +321,19 @@ impl Workflow {
         if let Some(sender) = &tx {
             sender.send(StatusMessage::Info(String::from("Applying importer updates ...")))?;
         }
-        // Apply each graph update
-        for mut u in updates? {
-            g.apply_update(&mut u, |_msg| {})
-                .map_err(|reason| AnnattoError::UpdateGraph(reason.to_string()))?;
+        // collect all updates in a single update to only have a single call to `apply_update`
+        let mut super_update = GraphUpdate::new();
+        for u in updates? {
+            for uer in u.iter()? {
+                let ue = uer?;
+                let event = ue.1;
+                super_update.add_event(event);
+            }
         }
-
+        // Apply super update
+        g.apply_update(&mut super_update, |_msg| {})
+            .map_err(|reason| AnnattoError::UpdateGraph(reason.to_string()))?;
+        
         // Execute all manipulators in sequence
         for desc in self.manipulator.iter() {
             desc.module

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -318,6 +318,9 @@ impl Workflow {
                 self.execute_single_importer(step, tx.clone())
             })
             .collect();
+        if let Some(sender) = &tx {
+            sender.send(StatusMessage::Info(String::from("Applying importer updates ...")))?;
+        }
         // Apply each graph update
         for mut u in updates? {
             g.apply_update(&mut u, |_msg| {})


### PR DESCRIPTION
Call `apply_update` on graph only once with all updates from all importers combined in a single `GraphUpdate` object. Multiple calls might slow the update process down.