### PR TITLE
Feature/merge check with property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 + merge checker always finishes and lists all misaligned documents
 + apply single combined update after imports are finished to avoid multiple calls to `apply_update`
 + externalized building of path/corpus structure for python modules to helper function
++ added property on.error to merge checker -- merge checker can now continue by dropping or forwarding erroneous documents if desired


### PR DESCRIPTION
Property implemented to allow merge checker to either:
+ fail when there are errors
+ drop documents with errors and continue
+ keep errors and continue (for debugging in ANNIS, for example)