### PR TITLE
Automatically format the code in pull requests

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,17 @@
+on: push
+
+name: Format Rust Code
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+          override: true
+      - uses: mbrobbel/rustfmt-check@0.3.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,9 +60,7 @@ pub enum AnnattoError {
     #[error("CSV error: {0}")]
     CSV(#[from] csv::Error),
     #[error("Checks failed: {failed_checks}")]
-    ChecksFailed {
-        failed_checks: String
-    }
+    ChecksFailed { failed_checks: String },
 }
 
 impl<T> From<std::sync::PoisonError<T>> for AnnattoError {

--- a/src/exporter/graphml.rs
+++ b/src/exporter/graphml.rs
@@ -1,11 +1,18 @@
-use std::{collections::BTreeMap, fs::{File, create_dir_all}, path::Path};
+use std::{
+    collections::BTreeMap,
+    fs::{create_dir_all, File},
+    path::Path,
+};
 
-use crate::{exporter::Exporter, progress::ProgressReporter, workflow::StatusSender, Module, error::AnnattoError};
-use graphannis_core::{
-    annostorage::ValueSearch,
-    graph::{NODE_TYPE_KEY,NODE_NAME_KEY}
+use crate::{
+    error::AnnattoError, exporter::Exporter, progress::ProgressReporter, workflow::StatusSender,
+    Module,
 };
 use graphannis::model::AnnotationComponentType;
+use graphannis_core::{
+    annostorage::ValueSearch,
+    graph::{NODE_NAME_KEY, NODE_TYPE_KEY},
+};
 
 pub struct GraphMLExporter {}
 
@@ -21,7 +28,6 @@ impl Module for GraphMLExporter {
     }
 }
 
-
 pub const PROPERTY_VISUALISATIONS: &str = "add.visualisations";
 const DEFAULT_VIS_STR: &str = "# configure visualizations here";
 
@@ -35,16 +41,40 @@ impl Exporter for GraphMLExporter {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let reporter = ProgressReporter::new(tx, self as &dyn Module, Some(output_path), 1)?;
         let file_name;
-        if let Some(part_of_c) = graph.get_all_components(Some(AnnotationComponentType::PartOf), None).first() {
-            let corpus_nodes = graph.get_node_annos().exact_anno_search(Some(NODE_TYPE_KEY.ns.as_str()), NODE_TYPE_KEY.name.as_str(), ValueSearch::Some("corpus"));
+        if let Some(part_of_c) = graph
+            .get_all_components(Some(AnnotationComponentType::PartOf), None)
+            .first()
+        {
+            let corpus_nodes = graph.get_node_annos().exact_anno_search(
+                Some(NODE_TYPE_KEY.ns.as_str()),
+                NODE_TYPE_KEY.name.as_str(),
+                ValueSearch::Some("corpus"),
+            );
             let part_of_storage = graph.get_graphstorage(part_of_c).unwrap();
-            let corpus_root = corpus_nodes.into_iter()
-                                    .find(|n| part_of_storage.get_outgoing_edges((*n).as_ref().unwrap().node).count() == 0)
-                                    .unwrap()?.node;
-            file_name = format!("{}.graphml", graph.get_node_annos().get_value_for_item(&corpus_root, &NODE_NAME_KEY)?.unwrap());
+            let corpus_root = corpus_nodes
+                .into_iter()
+                .find(|n| {
+                    part_of_storage
+                        .get_outgoing_edges((*n).as_ref().unwrap().node)
+                        .count()
+                        == 0
+                })
+                .unwrap()?
+                .node;
+            file_name = format!(
+                "{}.graphml",
+                graph
+                    .get_node_annos()
+                    .get_value_for_item(&corpus_root, &NODE_NAME_KEY)?
+                    .unwrap()
+            );
         } else {
             let reason = String::from("Could not determine file name for graphML.");
-            let err = AnnattoError::Export { reason: reason, exporter: self.module_name().to_string(), path: output_path.to_path_buf() };
+            let err = AnnattoError::Export {
+                reason: reason,
+                exporter: self.module_name().to_string(),
+                path: output_path.to_path_buf(),
+            };
             return Err(Box::new(err));
         }
         let output_file_path = match output_path.is_dir() {
@@ -57,12 +87,17 @@ impl Exporter for GraphMLExporter {
         let output_file = File::create(output_file_path.clone())?;
         let vis_str = match properties.get(&PROPERTY_VISUALISATIONS.to_string()) {
             None => DEFAULT_VIS_STR,
-            Some(visualisations) => visualisations
+            Some(visualisations) => visualisations,
         };
         reporter.info(format!("Starting export to {}", &output_file_path.display()).as_str())?;
-        graphannis_core::graph::serialization::graphml::export(graph, Some(format!("\n{}\n", vis_str).as_str()), output_file, |msg| {
-            reporter.info(msg).expect("Could not send status message");
-        })?;
+        graphannis_core::graph::serialization::graphml::export(
+            graph,
+            Some(format!("\n{}\n", vis_str).as_str()),
+            output_file,
+            |msg| {
+                reporter.info(msg).expect("Could not send status message");
+            },
+        )?;
         reporter.worked(1)?;
         Ok(())
     }

--- a/src/manipulator/check.rs
+++ b/src/manipulator/check.rs
@@ -1,10 +1,13 @@
 use std::env::temp_dir;
 
 use csv::ReaderBuilder;
-use graphannis::{AnnotationGraph, corpusstorage::{SearchQuery, QueryLanguage}, CorpusStorage};
+use graphannis::{
+    corpusstorage::{QueryLanguage, SearchQuery},
+    AnnotationGraph, CorpusStorage,
+};
 use tempfile::tempdir_in;
 
-use crate::{Manipulator, Module, error::AnnattoError};
+use crate::{error::AnnattoError, Manipulator, Module};
 
 pub const MODULE_NAME: &str = "check";
 const PROP_CONFIG_PATH: &str = "config.path";
@@ -25,40 +28,53 @@ impl Module for Check {
 }
 
 fn read_config_file(path: &str) -> Result<Vec<(String, String)>, Box<dyn std::error::Error>> {
-    let mut reader = ReaderBuilder::new().delimiter(CONFIG_FILE_ENTRY_SEP).from_path(path)?;
+    let mut reader = ReaderBuilder::new()
+        .delimiter(CONFIG_FILE_ENTRY_SEP)
+        .from_path(path)?;
     let mut checks = Vec::new();
-        for (line_index, entry) in reader.records().into_iter().enumerate() {
-            let record = entry?;
-            if record.len() != 2 {
-                let message = format!("Entry in line {} has invalid length ({} columns instead of 2).", line_index, record.len());
-                let err = AnnattoError::Manipulator { reason: message, manipulator: MODULE_NAME.to_string() };
-                return Err(Box::new(err));
-            }
-            checks.push((record.get(0).unwrap().trim().to_string(), record.get(1).unwrap().trim().to_string()))
+    for (line_index, entry) in reader.records().into_iter().enumerate() {
+        let record = entry?;
+        if record.len() != 2 {
+            let message = format!(
+                "Entry in line {} has invalid length ({} columns instead of 2).",
+                line_index,
+                record.len()
+            );
+            let err = AnnattoError::Manipulator {
+                reason: message,
+                manipulator: MODULE_NAME.to_string(),
+            };
+            return Err(Box::new(err));
         }
+        checks.push((
+            record.get(0).unwrap().trim().to_string(),
+            record.get(1).unwrap().trim().to_string(),
+        ))
+    }
     Ok(checks)
 }
 
-fn run_checks(graph: &mut AnnotationGraph, 
-             checks_and_results: Vec<(String, String)>) -> Result<(), Box<dyn std::error::Error>> {
+fn run_checks(
+    graph: &mut AnnotationGraph,
+    checks_and_results: Vec<(String, String)>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut fails = Vec::new();
     let corpus_name = "current";
-    let tmp_dir = tempdir_in(temp_dir())?;        
+    let tmp_dir = tempdir_in(temp_dir())?;
     graph.save_to(&tmp_dir.path().join(corpus_name))?;
-    let cs = CorpusStorage::with_auto_cache_size(&tmp_dir.path(), true)?;        
+    let cs = CorpusStorage::with_auto_cache_size(&tmp_dir.path(), true)?;
     for (query_s, expected_result) in checks_and_results {
         let result = run_query(&cs, &query_s[..]);
         if let Ok(n) = result {
             let passes = match expected_result.parse::<u64>() {
-                Ok(number) => {
-                    number == n
-                },
+                Ok(number) => number == n,
                 Err(_) => {
                     match &expected_result[..] {
                         "*" => n.ge(&0),
                         "+" => n.ge(&1),
                         "?" => n.ge(&0) && n.le(&1),
-                        _ => { // interpret numeric digit as query as well
+                        _ => {
+                            // interpret numeric digit as query as well
                             let second_result = run_query(&cs, &expected_result);
                             !second_result.is_err() && second_result.unwrap() == n
                         }
@@ -69,23 +85,27 @@ fn run_checks(graph: &mut AnnotationGraph,
                 fails.push(query_s.to_string());
             }
         } else {
-            fails.push(format!("Could not be processed: {},{}", query_s, &expected_result));
+            fails.push(format!(
+                "Could not be processed: {},{}",
+                query_s, &expected_result
+            ));
         }
     }
     if fails.is_empty() {
         Ok(())
     } else {
-        Err(Box::new(AnnattoError::ChecksFailed { failed_checks: fails.join("\n").to_string() }))
+        Err(Box::new(AnnattoError::ChecksFailed {
+            failed_checks: fails.join("\n").to_string(),
+        }))
     }
 }
 
-fn run_query(storage: &CorpusStorage, 
-             query_s: &str) -> Result<u64, Box<dyn std::error::Error>> {
+fn run_query(storage: &CorpusStorage, query_s: &str) -> Result<u64, Box<dyn std::error::Error>> {
     let query = SearchQuery {
         corpus_names: &["current"],
         query: query_s,
         query_language: QueryLanguage::AQL,
-        timeout: None
+        timeout: None,
     };
     let c = storage.count(query)?;
     Ok(c)
@@ -99,8 +119,13 @@ impl Manipulator for Check {
         _tx: Option<crate::workflow::StatusSender>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let config_path = match properties.get(&PROP_CONFIG_PATH.to_string()) {
-            None => return Err(Box::new(AnnattoError::Manipulator { reason: "No test file path provided".to_string(), manipulator: self.module_name().to_string() })),
-            Some(path_spec) => &path_spec[..]
+            None => {
+                return Err(Box::new(AnnattoError::Manipulator {
+                    reason: "No test file path provided".to_string(),
+                    manipulator: self.module_name().to_string(),
+                }))
+            }
+            Some(path_spec) => &path_spec[..],
         };
         let checks = read_config_file(config_path)?;
         run_checks(graph, checks)

--- a/src/manipulator/merge.rs
+++ b/src/manipulator/merge.rs
@@ -1,26 +1,25 @@
-use std::borrow::Cow;
-use std::collections::{HashMap,HashSet,BTreeMap};
-use std::convert::TryFrom;
-use crate::{Manipulator,Module};
 use crate::error::AnnattoError;
-use crate::workflow::{StatusMessage,StatusSender};
+use crate::workflow::{StatusMessage, StatusSender};
+use crate::{Manipulator, Module};
 use graphannis::{
-    graph::{Component,Edge},
-    model::{AnnotationComponentType,AnnotationComponent},
-    update::{GraphUpdate,UpdateEvent},
+    graph::{Component, Edge},
+    model::{AnnotationComponent, AnnotationComponentType},
+    update::{GraphUpdate, UpdateEvent},
     AnnotationGraph,
 };
 use graphannis_core::{
     annostorage::ValueSearch,
     dfs::CycleSafeDFS,
-    graph::{ANNIS_NS,NODE_NAME_KEY,NODE_TYPE_KEY},
-    types::{AnnoKey,ComponentType},
-    util::split_qname
+    graph::{ANNIS_NS, NODE_NAME_KEY, NODE_TYPE_KEY},
+    types::{AnnoKey, ComponentType},
+    util::split_qname,
 };
 use itertools::Itertools;
+use std::borrow::Cow;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::convert::TryFrom;
 
 pub struct Merge {}
-
 
 impl Default for Merge {
     fn default() -> Self {
@@ -46,7 +45,7 @@ enum MergerProperties {
     OptionalValues,
     OptionalChars,
     Silent,
-    ReportDetails
+    ReportDetails,
 }
 
 impl ToString for MergerProperties {
@@ -59,16 +58,15 @@ impl ToString for MergerProperties {
             Self::OptionalValues => PROP_OPTIONAL_VALUES.to_string(),
             Self::OptionalChars => PROP_OPTIONAL_CHARS.to_string(),
             Self::Silent => PROP_SILENT.to_string(),
-            Self::ReportDetails => PROP_REPORT_DETAILS.to_string()
+            Self::ReportDetails => PROP_REPORT_DETAILS.to_string(),
         }
     }
 }
 
-
-enum ErrorPolicy {    
+enum ErrorPolicy {
     Fail,
     Drop,
-    Forward
+    Forward,
 }
 
 impl TryFrom<Option<&String>> for ErrorPolicy {
@@ -76,7 +74,7 @@ impl TryFrom<Option<&String>> for ErrorPolicy {
     fn try_from(value: Option<&String>) -> Result<Self, Self::Error> {
         match value {
             None => Ok(ErrorPolicy::default()),
-            Some(v) => ErrorPolicy::try_from(v)
+            Some(v) => ErrorPolicy::try_from(v),
         }
     }
 }
@@ -88,9 +86,10 @@ impl TryFrom<&String> for ErrorPolicy {
             "fail" => Ok(ErrorPolicy::Fail),
             "drop" => Ok(ErrorPolicy::Drop),
             "forward" => Ok(ErrorPolicy::Forward),
-            _ => Err(AnnattoError::Manipulator { 
-                reason: format!("Undefined value for property {}: {}", PROP_ON_ERROR, value), 
-                manipulator: String::from(MODULE_NAME) })
+            _ => Err(AnnattoError::Manipulator {
+                reason: format!("Undefined value for property {}: {}", PROP_ON_ERROR, value),
+                manipulator: String::from(MODULE_NAME),
+            }),
         }
     }
 }
@@ -101,7 +100,6 @@ impl Default for ErrorPolicy {
     }
 }
 
-
 fn clean_value(value: &Cow<str>, remove_chars: &HashSet<char>) -> String {
     let mut value_ = String::new();
     for c in value.chars() {
@@ -109,23 +107,51 @@ fn clean_value(value: &Cow<str>, remove_chars: &HashSet<char>) -> String {
             value_.push(c);
         }
     }
-    return value_
+    return value_;
 }
 
-
 impl Merge {
-    fn retrieve_ordered_nodes<'a>(&self, graph: &AnnotationGraph, order_names: Vec<&'a str>) -> Result<HashMap<String, HashMap<&'a str, std::vec::IntoIter<u64>>>, Box<dyn std::error::Error>> {        
-        let mut ordered_items_by_doc: HashMap<String, HashMap<&str, std::vec::IntoIter<u64>>> = HashMap::new();
+    fn retrieve_ordered_nodes<'a>(
+        &self,
+        graph: &AnnotationGraph,
+        order_names: Vec<&'a str>,
+    ) -> Result<
+        HashMap<String, HashMap<&'a str, std::vec::IntoIter<u64>>>,
+        Box<dyn std::error::Error>,
+    > {
+        let mut ordered_items_by_doc: HashMap<String, HashMap<&str, std::vec::IntoIter<u64>>> =
+            HashMap::new();
         let node_annos = graph.get_node_annos();
         for order_name in order_names {
-            let c = AnnotationComponent::new(AnnotationComponentType::Ordering, ANNIS_NS.into(), order_name.into());            
-            if let Some(ordering) = graph.get_graphstorage(&c) {                
-                let start_nodes = ordering.source_nodes().filter(|n| ordering.get_ingoing_edges(*n.as_ref().unwrap()).count() == 0).collect_vec();
+            let c = AnnotationComponent::new(
+                AnnotationComponentType::Ordering,
+                ANNIS_NS.into(),
+                order_name.into(),
+            );
+            if let Some(ordering) = graph.get_graphstorage(&c) {
+                let start_nodes = ordering
+                    .source_nodes()
+                    .filter(|n| ordering.get_ingoing_edges(*n.as_ref().unwrap()).count() == 0)
+                    .collect_vec();
                 // there should be one start node per document
-                let doc_names = start_nodes.iter()
-                                            .map(|n| node_annos.get_value_for_item(n.as_ref().unwrap(), &NODE_NAME_KEY).unwrap().unwrap())
-                                            .map(|v| v.split("/").last().unwrap().split("#").next().unwrap().to_string())
-                                            .collect_vec();
+                let doc_names = start_nodes
+                    .iter()
+                    .map(|n| {
+                        node_annos
+                            .get_value_for_item(n.as_ref().unwrap(), &NODE_NAME_KEY)
+                            .unwrap()
+                            .unwrap()
+                    })
+                    .map(|v| {
+                        v.split("/")
+                            .last()
+                            .unwrap()
+                            .split("#")
+                            .next()
+                            .unwrap()
+                            .to_string()
+                    })
+                    .collect_vec();
                 for doc_name in &doc_names {
                     if !ordered_items_by_doc.contains_key(doc_name) {
                         ordered_items_by_doc.insert(doc_name.to_string(), HashMap::new());
@@ -135,46 +161,64 @@ impl Merge {
                     let start_node = start_node_r?;
                     let mut nodes: Vec<u64> = Vec::new();
                     nodes.push(start_node);
-                    let dfs = CycleSafeDFS::new(ordering.as_edgecontainer(), start_node, 1, usize::MAX);
+                    let dfs =
+                        CycleSafeDFS::new(ordering.as_edgecontainer(), start_node, 1, usize::MAX);
                     for entry in dfs {
                         nodes.push(entry?.node);
                     }
-                    if nodes.is_empty() {                 
-                        let err = AnnattoError::Manipulator { reason: format!("Ordering `{}` does not connect any nodes.", order_name), manipulator: self.module_name().to_string() };
-                        return Err(Box::new(err))
+                    if nodes.is_empty() {
+                        let err = AnnattoError::Manipulator {
+                            reason: format!(
+                                "Ordering `{}` does not connect any nodes.",
+                                order_name
+                            ),
+                            manipulator: self.module_name().to_string(),
+                        };
+                        return Err(Box::new(err));
                     }
-                    ordered_items_by_doc.get_mut(&doc_name).unwrap().insert(order_name, nodes.into_iter());
+                    ordered_items_by_doc
+                        .get_mut(&doc_name)
+                        .unwrap()
+                        .insert(order_name, nodes.into_iter());
                 }
             } else {
-                let err = AnnattoError::Manipulator { reason: format!("Required ordering `{}` does not exist.", order_name), manipulator: self.module_name().to_string() };
-                return Err(Box::new(err))
-            }            
+                let err = AnnattoError::Manipulator {
+                    reason: format!("Required ordering `{}` does not exist.", order_name),
+                    manipulator: self.module_name().to_string(),
+                };
+                return Err(Box::new(err));
+            }
         }
         Ok(ordered_items_by_doc)
     }
 
-    fn map_text_nodes(&self, 
-                      graph: &AnnotationGraph, 
-                      updates: &mut GraphUpdate, 
-                      target_key: &AnnoKey, 
-                      ordered_items_by_doc: HashMap<String, HashMap<&str, std::vec::IntoIter<u64>>>,
-                      optionals: HashSet<String>,
-                      optional_chars: HashSet<char>,
-                      docs_with_errors: &mut HashSet<String>,
-                      tx: &Option<StatusSender>) -> Result<HashMap<u64, u64>, Box<dyn std::error::Error>> {
+    fn map_text_nodes(
+        &self,
+        graph: &AnnotationGraph,
+        updates: &mut GraphUpdate,
+        target_key: &AnnoKey,
+        ordered_items_by_doc: HashMap<String, HashMap<&str, std::vec::IntoIter<u64>>>,
+        optionals: HashSet<String>,
+        optional_chars: HashSet<char>,
+        docs_with_errors: &mut HashSet<String>,
+        tx: &Option<StatusSender>,
+    ) -> Result<HashMap<u64, u64>, Box<dyn std::error::Error>> {
         let mut node_map: HashMap<u64, u64> = HashMap::new();
         let node_annos = graph.get_node_annos();
         for (doc_name, mut ordered_items_by_name) in ordered_items_by_doc {
             let ordered_keep_items_opt = ordered_items_by_name.remove(target_key.name.as_str());
-            if ordered_keep_items_opt.is_none() {                
+            if ordered_keep_items_opt.is_none() {
                 if let Some(sender) = tx {
-                    let message = format!("Document {} does not contain an ordering {}", &doc_name, &target_key.name);
+                    let message = format!(
+                        "Document {} does not contain an ordering {}",
+                        &doc_name, &target_key.name
+                    );
                     sender.send(StatusMessage::Warning(message))?;
                 }
                 docs_with_errors.insert(doc_name);
-                continue
+                continue;
             }
-            let ordered_keep_items = ordered_keep_items_opt.unwrap(); 
+            let ordered_keep_items = ordered_keep_items_opt.unwrap();
             let mut order_names = HashSet::new();
             for (k, _) in &ordered_items_by_name {
                 order_names.insert(k.to_string());
@@ -184,82 +228,111 @@ impl Merge {
                 let ref_val = match node_annos.get_value_for_item(&item, target_key)? {
                     Some(v) => v,
                     None => {
-                        let critical_node = node_annos.get_value_for_item(&item, &NODE_NAME_KEY)?.unwrap();
-                        return Err(Box::new(AnnattoError::Manipulator { reason: format!("Could not determine annotation value for key {}::{} @ {}", 
-                                                                                        target_key.ns, 
-                                                                                        target_key.name,
-                                                                                        critical_node), 
-                                                                                        manipulator: self.module_name().to_string() }));
+                        let critical_node = node_annos
+                            .get_value_for_item(&item, &NODE_NAME_KEY)?
+                            .unwrap();
+                        return Err(Box::new(AnnattoError::Manipulator {
+                            reason: format!(
+                                "Could not determine annotation value for key {}::{} @ {}",
+                                target_key.ns, target_key.name, critical_node
+                            ),
+                            manipulator: self.module_name().to_string(),
+                        }));
                     }
                 };
                 let ref_is_optional = optionals.contains(&ref_val.to_string());
-                let ref_node_name = node_annos.get_value_for_item(&item, &NODE_NAME_KEY)?.unwrap();  // existence guaranteed                                
+                let ref_node_name = node_annos
+                    .get_value_for_item(&item, &NODE_NAME_KEY)?
+                    .unwrap(); // existence guaranteed
                 for other_name in &order_names {
                     let mut finished = false;
-                    while !finished {   
-                        let other_opt= if unused_by_name.contains_key(other_name) {
+                    while !finished {
+                        let other_opt = if unused_by_name.contains_key(other_name) {
                             unused_by_name.remove(other_name)
                         } else {
-                            ordered_items_by_name.get_mut(other_name.as_str()).unwrap().next()
+                            ordered_items_by_name
+                                .get_mut(other_name.as_str())
+                                .unwrap()
+                                .next()
                         };
                         if let Some(other_item) = other_opt {
-                            let other_key = AnnoKey {ns: "".into(), name: other_name.into()};
-                            let other_val = node_annos.get_value_for_item(&other_item, &other_key)?.unwrap();
-                            if ref_val == other_val || 
-                                !optional_chars.is_empty() && clean_value(&ref_val, &optional_chars) == clean_value(&other_val, &optional_chars) {  // text values match
-                                let anno_keys = node_annos.get_all_keys_for_item(&other_item, None, None)?;
+                            let other_key = AnnoKey {
+                                ns: "".into(),
+                                name: other_name.into(),
+                            };
+                            let other_val = node_annos
+                                .get_value_for_item(&other_item, &other_key)?
+                                .unwrap();
+                            if ref_val == other_val
+                                || !optional_chars.is_empty()
+                                    && clean_value(&ref_val, &optional_chars)
+                                        == clean_value(&other_val, &optional_chars)
+                            {
+                                // text values match
+                                let anno_keys =
+                                    node_annos.get_all_keys_for_item(&other_item, None, None)?;
                                 // annotations directly on the ordered node
                                 for ak in anno_keys {
                                     let anno_name = ak.name.to_string();
-                                    if ak.ns != ANNIS_NS && !order_names.contains(&anno_name) {                                
-                                        let av = node_annos.get_value_for_item(&other_item, ak.as_ref())?.unwrap();  // existence guaranteed
-                                        updates.add_event(UpdateEvent::AddNodeLabel { node_name: ref_node_name.to_string(),
-                                                                                    anno_ns: ak.ns.to_string(), 
-                                                                                    anno_name: anno_name, 
-                                                                                    anno_value: av.to_string() })?;
+                                    if ak.ns != ANNIS_NS && !order_names.contains(&anno_name) {
+                                        let av = node_annos
+                                            .get_value_for_item(&other_item, ak.as_ref())?
+                                            .unwrap(); // existence guaranteed
+                                        updates.add_event(UpdateEvent::AddNodeLabel {
+                                            node_name: ref_node_name.to_string(),
+                                            anno_ns: ak.ns.to_string(),
+                                            anno_name: anno_name,
+                                            anno_value: av.to_string(),
+                                        })?;
                                     }
                                 }
                                 // delete ordered node, the rest (edges and labels) should theoretically die as a consequence
-                                let other_node_name = node_annos.get_value_for_item(&other_item, &NODE_NAME_KEY)?.unwrap().to_string();  // existence guaranteed
-                                updates.add_event(UpdateEvent::DeleteNode { node_name: other_node_name })?;                        
-                                node_map.insert(other_item, item); 
-                                finished = true;                       
-                            } else {  // text values don't match
+                                let other_node_name = node_annos
+                                    .get_value_for_item(&other_item, &NODE_NAME_KEY)?
+                                    .unwrap()
+                                    .to_string(); // existence guaranteed
+                                updates.add_event(UpdateEvent::DeleteNode {
+                                    node_name: other_node_name,
+                                })?;
+                                node_map.insert(other_item, item);
+                                finished = true;
+                            } else {
+                                // text values don't match
                                 let other_is_optional = optionals.contains(&other_val.to_string());
-                                if  ref_is_optional && !other_is_optional {
+                                if ref_is_optional && !other_is_optional {
                                     // advance outer, do not advance inner
                                     unused_by_name.insert(other_name.to_string(), other_item);
                                     finished = true;
-                                }
-                                else if !ref_is_optional && other_is_optional {
+                                } else if !ref_is_optional && other_is_optional {
                                     // advance inner, do not advance outer
-                                    // i. e. do nothing                                    
-                                }
-                                else if !ref_is_optional && !other_is_optional {
+                                    // i. e. do nothing
+                                } else if !ref_is_optional && !other_is_optional {
                                     // match expected, advance both
                                     if let Some(sender) = tx {
                                         let message = StatusMessage::Warning(format!("{}: {}={} and {}={} do not match. Mismatch could not be resolved.", &doc_name, &target_key.name, ref_val, other_name, other_val));
                                         sender.send(message)?;
                                     }
-                                    node_map.insert(other_item, item);  // map anyway to be compliant with ErrorPolicy::Forward
+                                    node_map.insert(other_item, item); // map anyway to be compliant with ErrorPolicy::Forward
                                     docs_with_errors.insert(doc_name.to_string());
                                     finished = true;
-                                }
-                                else {
+                                } else {
                                     // both optional, but non-matching, advance both
                                     finished = true;
                                 }
-                            }                    
+                            }
                         } else {
                             // no further nodes
                             if !ref_is_optional {
-                                let message = format!("Ran out of nodes for ordering `{}` in document {}", other_name, &doc_name);
+                                let message = format!(
+                                    "Ran out of nodes for ordering `{}` in document {}",
+                                    other_name, &doc_name
+                                );
                                 if let Some(sender) = tx {
                                     sender.send(StatusMessage::Warning(message))?;
                                     docs_with_errors.insert(doc_name.to_string());
                                 }
                             }
-                            finished = true;                            
+                            finished = true;
                         }
                     }
                 }
@@ -268,40 +341,47 @@ impl Merge {
         Ok(node_map)
     }
 
-    fn merge_all_components(&self, 
-                            graph: &AnnotationGraph, 
-                            updates: &mut GraphUpdate,
-                            skip_components: HashSet<AnnotationComponent>, 
-                            node_map: HashMap<u64, u64>,
-                            _docs_with_errors: &mut HashSet<String>,  //TODO shortcut mappings?
-                            tx: &Option<StatusSender>) -> Result<(), Box<dyn std::error::Error>> {        
-        for (edge_component_type, switch_source) in [(AnnotationComponentType::Coverage, false), 
-                                                             (AnnotationComponentType::Dominance, false), 
-                                                             (AnnotationComponentType::Pointing, true)] {
-            for edge_component in graph.get_all_components(Some(edge_component_type.clone()), None) {
+    fn merge_all_components(
+        &self,
+        graph: &AnnotationGraph,
+        updates: &mut GraphUpdate,
+        skip_components: HashSet<AnnotationComponent>,
+        node_map: HashMap<u64, u64>,
+        _docs_with_errors: &mut HashSet<String>, //TODO shortcut mappings?
+        tx: &Option<StatusSender>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        for (edge_component_type, switch_source) in [
+            (AnnotationComponentType::Coverage, false),
+            (AnnotationComponentType::Dominance, false),
+            (AnnotationComponentType::Pointing, true),
+        ] {
+            for edge_component in graph.get_all_components(Some(edge_component_type.clone()), None)
+            {
                 if skip_components.contains(&edge_component) {
                     if let Some(sender) = tx {
                         let message = format!("Skipping component {}", &edge_component.name);
                         sender.send(StatusMessage::Info(message))?;
                     }
                     continue;
-                }                
+                }
                 self.merge_component(graph, updates, edge_component, switch_source, &node_map, tx)?;
             }
         }
         Ok(())
     }
 
-    fn merge_component(&self, 
-                       graph: &AnnotationGraph,
-                       updates: &mut GraphUpdate,
-                       edge_component: Component<AnnotationComponentType>,
-                       switch_source: bool, 
-                       node_map: &HashMap<u64, u64>,
-                       tx: &Option<StatusSender>) -> Result<(), Box<dyn std::error::Error>> {
+    fn merge_component(
+        &self,
+        graph: &AnnotationGraph,
+        updates: &mut GraphUpdate,
+        edge_component: Component<AnnotationComponentType>,
+        switch_source: bool,
+        node_map: &HashMap<u64, u64>,
+        tx: &Option<StatusSender>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let mut report_missing = HashSet::new();
         let edge_component_name = &edge_component.name;
-        let edge_component_type = edge_component.get_type();                    
+        let edge_component_type = edge_component.get_type();
         let layer_name = edge_component.layer.to_string();
         let node_annos = graph.get_node_annos();
         if let Some(edge_storage) = graph.get_graphstorage(&edge_component) {
@@ -309,100 +389,150 @@ impl Merge {
             let edge_annos = edge_storage.get_anno_storage();
             for source_node_r in edge_storage.source_nodes() {
                 let source_node = source_node_r?;
-                let source_node_name = node_annos.get_value_for_item(&source_node, &NODE_NAME_KEY)?.unwrap(); // existence guaranteed
+                let source_node_name = node_annos
+                    .get_value_for_item(&source_node, &NODE_NAME_KEY)?
+                    .unwrap(); // existence guaranteed
                 let new_source_name = if switch_source {
                     if let Some(new_source_node) = node_map.get(&source_node) {
-                        node_annos.get_value_for_item(new_source_node, &NODE_NAME_KEY)?.unwrap().to_string()
+                        node_annos
+                            .get_value_for_item(new_source_node, &NODE_NAME_KEY)?
+                            .unwrap()
+                            .to_string()
                     } else {
                         if let Some(sender) = tx {
                             let message = format!("Could not determine new source of an edge in component {}/{}, the edge will be dropped", &edge_component_type.to_string(), &edge_component_name);
-                            sender.send(StatusMessage::Warning(message))?;                                    
+                            sender.send(StatusMessage::Warning(message))?;
                         }
                         continue;
                     }
                 } else {
                     source_node_name.to_string()
                 };
-                let edge_dfs = CycleSafeDFS::new(edge_storage.as_edgecontainer(), source_node, 1, 1);
+                let edge_dfs =
+                    CycleSafeDFS::new(edge_storage.as_edgecontainer(), source_node, 1, 1);
                 report_missing.clear();
                 for target_r in edge_dfs {
-                    let target = target_r?.node;       
-                    if let Some(new_target) = node_map.get(&target) {                            
+                    let target = target_r?.node;
+                    if let Some(new_target) = node_map.get(&target) {
                         // new child still exists in target graph
-                        let target_name = node_annos.get_value_for_item(&target, &NODE_NAME_KEY)?.unwrap();  // existence guaranteed    
-                        let new_target_name = node_annos.get_value_for_item(new_target, &NODE_NAME_KEY)?.unwrap();                        
-                        updates.add_event(UpdateEvent::DeleteEdge { source_node: source_node_name.to_string(), 
-                                                                    target_node: target_name.to_string(), 
-                                                                    layer: layer_name.to_string(),
-                                                                    component_type: edge_component_type.to_string(), 
-                                                                    component_name: edge_component_name.to_string() })?;                        
-                        updates.add_event(UpdateEvent::AddEdge { source_node: new_source_name.clone(), 
-                                                                    target_node: new_target_name.to_string(), 
-                                                                    layer: layer_name.to_string(), 
-                                                                    component_type: edge_component_type.to_string(), 
-                                                                    component_name: edge_component_name.to_string() })?;                           
-                        // check edge for annotations that need to be transferred        
-                        let edge = Edge {source: source_node, target: target}; // TODO at least for the case of pointing relations the same container might contain more than one edge, or am I wrong?                
+                        let target_name = node_annos
+                            .get_value_for_item(&target, &NODE_NAME_KEY)?
+                            .unwrap(); // existence guaranteed
+                        let new_target_name = node_annos
+                            .get_value_for_item(new_target, &NODE_NAME_KEY)?
+                            .unwrap();
+                        updates.add_event(UpdateEvent::DeleteEdge {
+                            source_node: source_node_name.to_string(),
+                            target_node: target_name.to_string(),
+                            layer: layer_name.to_string(),
+                            component_type: edge_component_type.to_string(),
+                            component_name: edge_component_name.to_string(),
+                        })?;
+                        updates.add_event(UpdateEvent::AddEdge {
+                            source_node: new_source_name.clone(),
+                            target_node: new_target_name.to_string(),
+                            layer: layer_name.to_string(),
+                            component_type: edge_component_type.to_string(),
+                            component_name: edge_component_name.to_string(),
+                        })?;
+                        // check edge for annotations that need to be transferred
+                        let edge = Edge {
+                            source: source_node,
+                            target: target,
+                        }; // TODO at least for the case of pointing relations the same container might contain more than one edge, or am I wrong?
                         for k in edge_annos.get_all_keys_for_item(&edge, None, None)? {
-                            if k.ns != ANNIS_NS {                                    
-                                let v = edge_annos.get_value_for_item(&edge, &*k)?.unwrap();  // guaranteed to exist
-                                let u = UpdateEvent::AddEdgeLabel { source_node: new_source_name.clone(), 
-                                                                                    target_node: new_target_name.to_string(), 
-                                                                                    layer: layer_name.to_string(), 
-                                                                                    component_type: edge_component_type.to_string(), 
-                                                                                    component_name: edge_component_name.to_string(), 
-                                                                                    anno_ns: k.ns.to_string(), 
-                                                                                    anno_name: k.name.to_string(), 
-                                                                                    anno_value: v.to_string() };
+                            if k.ns != ANNIS_NS {
+                                let v = edge_annos.get_value_for_item(&edge, &*k)?.unwrap(); // guaranteed to exist
+                                let u = UpdateEvent::AddEdgeLabel {
+                                    source_node: new_source_name.clone(),
+                                    target_node: new_target_name.to_string(),
+                                    layer: layer_name.to_string(),
+                                    component_type: edge_component_type.to_string(),
+                                    component_name: edge_component_name.to_string(),
+                                    anno_ns: k.ns.to_string(),
+                                    anno_name: k.name.to_string(),
+                                    anno_value: v.to_string(),
+                                };
                                 updates.add_event(u)?;
                             }
                         }
                     } else {
                         // child does not exist in target graph, which must be legal if we allow texts to only partially match (e. g. in the case of dropped punctuation)
                         // it could also be the case that the source and target node are not in the node_map bc they are not ordered nodes and thus don't require to be modified
-                        report_missing.insert(node_annos.get_value_for_item(&target, &NODE_NAME_KEY)?.unwrap());
+                        report_missing.insert(
+                            node_annos
+                                .get_value_for_item(&target, &NODE_NAME_KEY)?
+                                .unwrap(),
+                        );
                     }
                 }
                 if !report_missing.is_empty() && tx.is_some() {
                     let sender = tx.as_ref().unwrap();
-                    sender.send(StatusMessage::Info(format!("Not all children of node {} ({}::{}) available in target graph: {:?}", &source_node_name, &layer_name, &edge_component_name, &report_missing)))?;
+                    sender.send(StatusMessage::Info(format!(
+                        "Not all children of node {} ({}::{}) available in target graph: {:?}",
+                        &source_node_name, &layer_name, &edge_component_name, &report_missing
+                    )))?;
                 }
             }
         }
         Ok(())
     }
 
-    fn handle_document_errors(&self, graph: &AnnotationGraph, updates: &mut GraphUpdate, docs_with_errors: HashSet<String>, policy: ErrorPolicy, tx: &Option<StatusSender>) -> Result<(), Box<dyn std::error::Error>>{
+    fn handle_document_errors(
+        &self,
+        graph: &AnnotationGraph,
+        updates: &mut GraphUpdate,
+        docs_with_errors: HashSet<String>,
+        policy: ErrorPolicy,
+        tx: &Option<StatusSender>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let node_annos = graph.get_node_annos();
         let n = docs_with_errors.len();
         if n > 0 {
-            let docs_s = docs_with_errors.iter().sorted().join("\n");            
+            let docs_s = docs_with_errors.iter().sorted().join("\n");
             if let Some(sender) = &tx {
                 let message = match policy {
                     ErrorPolicy::Fail => {
                         let msg = format!("{} documents with ill-merged tokens:\n{}", n, docs_s);
-                        let err = AnnattoError::Manipulator { reason: msg, manipulator: self.module_name().to_string() };
+                        let err = AnnattoError::Manipulator {
+                            reason: msg,
+                            manipulator: self.module_name().to_string(),
+                        };
                         StatusMessage::Failed(err)
-                    },
+                    }
                     ErrorPolicy::Drop => {
                         for doc_node_name in docs_with_errors {
-                            // get all doc nodes with doc_id 
-                            let corpus_nodes = node_annos.exact_anno_search(Some(NODE_TYPE_KEY.ns.as_str()), NODE_TYPE_KEY.name.as_str(), ValueSearch::Some("corpus"))
-                                                    .into_iter()
-                                                    .map(|m| m.unwrap().node)
-                                                    .collect::<HashSet<u64>>();
-                            let nodes_with_doc_name = node_annos.exact_anno_search(Some(NODE_NAME_KEY.ns.as_str()), NODE_NAME_KEY.name.as_str(), ValueSearch::Some(doc_node_name.as_str()))
-                                                    .into_iter()
-                                                    .map(|m| m.unwrap().node)
-                                                    .collect::<HashSet<u64>>();
+                            // get all doc nodes with doc_id
+                            let corpus_nodes = node_annos
+                                .exact_anno_search(
+                                    Some(NODE_TYPE_KEY.ns.as_str()),
+                                    NODE_TYPE_KEY.name.as_str(),
+                                    ValueSearch::Some("corpus"),
+                                )
+                                .into_iter()
+                                .map(|m| m.unwrap().node)
+                                .collect::<HashSet<u64>>();
+                            let nodes_with_doc_name = node_annos
+                                .exact_anno_search(
+                                    Some(NODE_NAME_KEY.ns.as_str()),
+                                    NODE_NAME_KEY.name.as_str(),
+                                    ValueSearch::Some(doc_node_name.as_str()),
+                                )
+                                .into_iter()
+                                .map(|m| m.unwrap().node)
+                                .collect::<HashSet<u64>>();
                             for doc_node_id in corpus_nodes.intersection(&nodes_with_doc_name) {
-                                let doc_name = node_annos.get_value_for_item(doc_node_id, &NODE_NAME_KEY)?.unwrap();
-                                updates.add_event(UpdateEvent::DeleteNode { node_name: doc_name.to_string() })?; 
+                                let doc_name = node_annos
+                                    .get_value_for_item(doc_node_id, &NODE_NAME_KEY)?
+                                    .unwrap();
+                                updates.add_event(UpdateEvent::DeleteNode {
+                                    node_name: doc_name.to_string(),
+                                })?;
                             }
-                        };
+                        }
                         let msg = format!("{} documents with ill-merged tokens will be dropped from the corpus:\n{}", n, docs_s);
                         StatusMessage::Warning(msg)
-                    },
+                    }
                     _ => {
                         let msg = format!("BE AWARE that the corpus contains severe merging issues in the following {} documents:\n{}", n, docs_s);
                         StatusMessage::Warning(msg)
@@ -414,30 +544,38 @@ impl Merge {
         Ok(())
     }
 
-    fn skip_components_from_prop(&self, 
-                                 graph: &AnnotationGraph, 
-                                 property_val: Option<&String>) -> HashSet<Component<AnnotationComponentType>> {
-        let autogenerated_components = AnnotationComponentType::update_graph_index_components(graph).into_iter().collect::<HashSet<AnnotationComponent>>();
+    fn skip_components_from_prop(
+        &self,
+        graph: &AnnotationGraph,
+        property_val: Option<&String>,
+    ) -> HashSet<Component<AnnotationComponentType>> {
+        let autogenerated_components =
+            AnnotationComponentType::update_graph_index_components(graph)
+                .into_iter()
+                .collect::<HashSet<AnnotationComponent>>();
         let mut skip_components = HashSet::from(autogenerated_components);
         if let Some(skip_component_spec) = property_val {
             for spec in skip_component_spec.split(PROPVAL_SEP) {
                 let split_spec = split_qname(spec);
                 let layer = match split_spec.0 {
                     None => "",
-                    Some(v) => v
+                    Some(v) => v,
                 };
                 let name = split_spec.1;
                 for c in graph.get_all_components(None, Some(name)) {
                     if c.layer == layer {
-                        skip_components.insert(AnnotationComponent::new(c.get_type(), layer.into(), name.into()));
+                        skip_components.insert(AnnotationComponent::new(
+                            c.get_type(),
+                            layer.into(),
+                            name.into(),
+                        ));
                     }
                 }
             }
-        }  
+        }
         skip_components
     }
 }
-
 
 impl Manipulator for Merge {
     fn manipulate_corpus(
@@ -450,45 +588,72 @@ impl Manipulator for Merge {
             sender.send(StatusMessage::Info(String::from("Starting merge")))?;
         }
         // read properties
-        let on_error = ErrorPolicy::try_from(properties.get(&MergerProperties::OnError.to_string()))?;
-        let order_names = properties.get(&MergerProperties::CheckNames.to_string()).unwrap().split(PROPVAL_SEP).collect::<Vec<&str>>();  
-        let keep_name = properties.get(&MergerProperties::KeepName.to_string()).unwrap();
-        let keep_name_key = AnnoKey { ns: "".into(), name: keep_name.into() };
+        let on_error =
+            ErrorPolicy::try_from(properties.get(&MergerProperties::OnError.to_string()))?;
+        let order_names = properties
+            .get(&MergerProperties::CheckNames.to_string())
+            .unwrap()
+            .split(PROPVAL_SEP)
+            .collect::<Vec<&str>>();
+        let keep_name = properties
+            .get(&MergerProperties::KeepName.to_string())
+            .unwrap();
+        let keep_name_key = AnnoKey {
+            ns: "".into(),
+            name: keep_name.into(),
+        };
         let optional_toks = match properties.get(&MergerProperties::OptionalValues.to_string()) {
             None => HashSet::new(),
-            Some(v) => v.split("\",\"").map(|s| s.to_string().replace("\"", "")).collect::<HashSet<String>>()
+            Some(v) => v
+                .split("\",\"")
+                .map(|s| s.to_string().replace("\"", ""))
+                .collect::<HashSet<String>>(),
         };
         let optional_chars = match properties.get(&MergerProperties::OptionalChars.to_string()) {
             None => HashSet::new(),
-            Some(v) => v.split("','").map(|s| s.to_string().replace("'", "").parse::<char>().unwrap()).collect::<HashSet<char>>()
+            Some(v) => v
+                .split("','")
+                .map(|s| s.to_string().replace("'", "").parse::<char>().unwrap())
+                .collect::<HashSet<char>>(),
         };
         let silent = match properties.get(&MergerProperties::Silent.to_string()) {
             None => false,
-            Some(v) => v.parse::<bool>()?
+            Some(v) => v.parse::<bool>()?,
         };
-        let report_details = match  properties.get(&MergerProperties::ReportDetails.to_string()) {
+        let report_details = match properties.get(&MergerProperties::ReportDetails.to_string()) {
             None => false,
-            Some(v) => v.parse::<bool>()?
+            Some(v) => v.parse::<bool>()?,
         };
-        let sender_opt = if silent {
-            None
-        } else {
-            tx
-        };
+        let sender_opt = if silent { None } else { tx };
         // init
         let mut updates = GraphUpdate::default();
         let mut docs_with_errors = HashSet::new();
         // merge
         let ordered_items_by_doc = self.retrieve_ordered_nodes(graph, order_names.clone())?;
-        let reporter = if report_details {
-            &sender_opt
-        } else {
-            &None
-        };
-        let node_map: HashMap<u64, u64> = self.map_text_nodes(graph, &mut updates, &keep_name_key, ordered_items_by_doc, optional_toks, optional_chars, &mut docs_with_errors, reporter)?;                
-        let skip_components = self.skip_components_from_prop(graph, properties.get(&MergerProperties::SkipComponents.to_string()));
-        self.merge_all_components(graph, &mut updates, skip_components, node_map, &mut docs_with_errors, &sender_opt)?;
-        self.handle_document_errors(graph, &mut updates, docs_with_errors, on_error, &sender_opt)?;        
+        let reporter = if report_details { &sender_opt } else { &None };
+        let node_map: HashMap<u64, u64> = self.map_text_nodes(
+            graph,
+            &mut updates,
+            &keep_name_key,
+            ordered_items_by_doc,
+            optional_toks,
+            optional_chars,
+            &mut docs_with_errors,
+            reporter,
+        )?;
+        let skip_components = self.skip_components_from_prop(
+            graph,
+            properties.get(&MergerProperties::SkipComponents.to_string()),
+        );
+        self.merge_all_components(
+            graph,
+            &mut updates,
+            skip_components,
+            node_map,
+            &mut docs_with_errors,
+            &sender_opt,
+        )?;
+        self.handle_document_errors(graph, &mut updates, docs_with_errors, on_error, &sender_opt)?;
         graph.apply_update(&mut updates, |_msg| {})?;
         Ok(())
     }
@@ -507,69 +672,105 @@ mod tests {
     use std::collections::{BTreeMap, HashSet};
     use std::env::temp_dir;
 
-    use crate::Result;
-    use crate::manipulator::Manipulator;
     use crate::manipulator::merge::{Merge, MergerProperties};
+    use crate::manipulator::Manipulator;
+    use crate::Result;
 
-    use graphannis::{AnnotationGraph,CorpusStorage};
-    use graphannis::corpusstorage::{QueryLanguage,ResultOrder,SearchQuery};
-    use graphannis_core::annostorage::ValueSearch;
+    use graphannis::corpusstorage::{QueryLanguage, ResultOrder, SearchQuery};
     use graphannis::model::AnnotationComponentType;
-    use graphannis::update::{GraphUpdate,UpdateEvent};
-    use graphannis_core::graph::{ANNIS_NS, NODE_TYPE_KEY, NODE_NAME_KEY};
+    use graphannis::update::{GraphUpdate, UpdateEvent};
+    use graphannis::{AnnotationGraph, CorpusStorage};
+    use graphannis_core::annostorage::ValueSearch;
+    use graphannis_core::graph::{ANNIS_NS, NODE_NAME_KEY, NODE_TYPE_KEY};
     use itertools::Itertools;
-    use tempfile::{tempfile, tempdir_in};
+    use tempfile::{tempdir_in, tempfile};
 
     #[test]
     fn test_merger_in_mem() {
-        let r = core_test(false); 
+        let r = core_test(false);
         assert_eq!(r.is_ok(), true, "Probing core test result {:?}", r);
     }
 
     #[test]
     fn test_merger_on_disk() {
-        let r = core_test(true); 
+        let r = core_test(true);
         assert_eq!(r.is_ok(), true, "Probing core test result {:?}", r);
     }
 
     fn core_test(on_disk: bool) -> Result<()> {
         let mut g = input_graph(on_disk)?;
         let mut properties = BTreeMap::new();
-        properties.insert(MergerProperties::CheckNames.to_string(), "norm,text,syntext".to_string());
+        properties.insert(
+            MergerProperties::CheckNames.to_string(),
+            "norm,text,syntext".to_string(),
+        );
         properties.insert(MergerProperties::KeepName.to_string(), "norm".to_string());
-        properties.insert(MergerProperties::OptionalValues.to_string(), "\"NOISE\"".to_string());
+        properties.insert(
+            MergerProperties::OptionalValues.to_string(),
+            "\"NOISE\"".to_string(),
+        );
         let merger = Merge::default();
         let merge_r = merger.manipulate_corpus(&mut g, &properties, None);
         assert_eq!(merge_r.is_ok(), true, "Probing merge result {:?}", &merge_r);
         let mut e_g = expected_output_graph(on_disk)?;
         // corpus nodes
-        let e_corpus_nodes: HashSet<String> = e_g.get_node_annos()
-                                        .exact_anno_search(Some(&NODE_TYPE_KEY.ns), &NODE_TYPE_KEY.name, ValueSearch::Some("corpus"))
-                                        .into_iter()
-                                        .map(|r| r.unwrap().node)
-                                        .map(|id_| e_g.get_node_annos().get_value_for_item(&id_, &NODE_NAME_KEY).unwrap().unwrap().to_string())
-                                        .collect();
-        let g_corpus_nodes: HashSet<String> = g.get_node_annos()
-                                        .exact_anno_search(Some(&NODE_TYPE_KEY.ns), &NODE_TYPE_KEY.name, ValueSearch::Some("corpus"))
-                                        .into_iter()
-                                        .map(|r| r.unwrap().node)
-                                        .map(|id_| g.get_node_annos().get_value_for_item(&id_, &NODE_NAME_KEY).unwrap().unwrap().to_string())
-                                        .collect();
-        assert_eq!(e_corpus_nodes, g_corpus_nodes);  //TODO clarify: Delegate or assertion?
-        // test by components
-        let e_c_list = e_g.get_all_components(None, None)
-                                            .into_iter()
-                                            .filter(|c| e_g.get_graphstorage(c).unwrap().source_nodes().count() > 0)
-                                            .collect_vec();
-        let g_c_list = g.get_all_components(None, None)
-                                            .into_iter()
-                                            .filter(|c| g.get_graphstorage(c).unwrap().source_nodes().count() > 0)  // graph might contain empty components after merge
-                                            .collect_vec();
-        assert_eq!(e_c_list.len(), g_c_list.len(), "components expected:\n{:?};\ncomponents are:\n{:?}", &e_c_list, &g_c_list);
+        let e_corpus_nodes: HashSet<String> = e_g
+            .get_node_annos()
+            .exact_anno_search(
+                Some(&NODE_TYPE_KEY.ns),
+                &NODE_TYPE_KEY.name,
+                ValueSearch::Some("corpus"),
+            )
+            .into_iter()
+            .map(|r| r.unwrap().node)
+            .map(|id_| {
+                e_g.get_node_annos()
+                    .get_value_for_item(&id_, &NODE_NAME_KEY)
+                    .unwrap()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+        let g_corpus_nodes: HashSet<String> = g
+            .get_node_annos()
+            .exact_anno_search(
+                Some(&NODE_TYPE_KEY.ns),
+                &NODE_TYPE_KEY.name,
+                ValueSearch::Some("corpus"),
+            )
+            .into_iter()
+            .map(|r| r.unwrap().node)
+            .map(|id_| {
+                g.get_node_annos()
+                    .get_value_for_item(&id_, &NODE_NAME_KEY)
+                    .unwrap()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+        assert_eq!(e_corpus_nodes, g_corpus_nodes); //TODO clarify: Delegate or assertion?
+                                                    // test by components
+        let e_c_list = e_g
+            .get_all_components(None, None)
+            .into_iter()
+            .filter(|c| e_g.get_graphstorage(c).unwrap().source_nodes().count() > 0)
+            .collect_vec();
+        let g_c_list = g
+            .get_all_components(None, None)
+            .into_iter()
+            .filter(|c| g.get_graphstorage(c).unwrap().source_nodes().count() > 0) // graph might contain empty components after merge
+            .collect_vec();
+        assert_eq!(
+            e_c_list.len(),
+            g_c_list.len(),
+            "components expected:\n{:?};\ncomponents are:\n{:?}",
+            &e_c_list,
+            &g_c_list
+        );
         for c in e_c_list {
             let candidates = g.get_all_components(Some(c.get_type()), Some(c.name.as_str()));
             assert_eq!(candidates.len(), 1);
-            let c_o  = candidates.get(0);
+            let c_o = candidates.get(0);
             assert_eq!(&c, c_o.unwrap());
         }
         // test with queries
@@ -580,13 +781,13 @@ mod tests {
             "node >* norm",
             "cat",
             "node ->dep node",
-            "node ->dep[deprel=/.+/] node"
+            "node ->dep[deprel=/.+/] node",
         ];
         let corpus_name = "current";
         let tmp_dir_e = tempdir_in(temp_dir())?;
-        let tmp_dir_g = tempdir_in(temp_dir())?;        
+        let tmp_dir_g = tempdir_in(temp_dir())?;
         e_g.save_to(&tmp_dir_e.path().join(corpus_name))?;
-        g.save_to(&tmp_dir_g.path().join(corpus_name))?;        
+        g.save_to(&tmp_dir_g.path().join(corpus_name))?;
         let cs_e = CorpusStorage::with_auto_cache_size(&tmp_dir_e.path(), true)?;
         let cs_g = CorpusStorage::with_auto_cache_size(&tmp_dir_g.path(), true)?;
         for query_s in queries {
@@ -594,11 +795,16 @@ mod tests {
                 corpus_names: &[corpus_name],
                 query: query_s,
                 query_language: QueryLanguage::AQL,
-                timeout: None
+                timeout: None,
             };
             let matches_e = cs_e.find(query.clone(), 0, None, ResultOrder::Normal)?;
             let matches_g = cs_g.find(query, 0, None, ResultOrder::Normal)?;
-            assert_eq!(matches_e.len(), matches_g.len(), "Failed with query: {}", query_s);
+            assert_eq!(
+                matches_e.len(),
+                matches_g.len(),
+                "Failed with query: {}",
+                query_s
+            );
             for (m_e, m_g) in matches_e.into_iter().zip(matches_g.into_iter()) {
                 assert_eq!(m_e, m_g);
             }
@@ -609,13 +815,23 @@ mod tests {
     #[test]
     fn test_export_mem() {
         let export = export_test(false);
-        assert_eq!(export.is_ok(), true, "Export test ends with Err: {:?}", &export);
+        assert_eq!(
+            export.is_ok(),
+            true,
+            "Export test ends with Err: {:?}",
+            &export
+        );
     }
 
     #[test]
     fn test_export_disk() {
         let export = export_test(true);
-        assert_eq!(export.is_ok(), true, "Export test ends with Err: {:?}", &export);
+        assert_eq!(
+            export.is_ok(),
+            true,
+            "Export test ends with Err: {:?}",
+            &export
+        );
     }
 
     fn export_test(on_disk: bool) -> Result<()> {
@@ -624,9 +840,13 @@ mod tests {
         properties.insert("check.names".to_string(), "norm,text,syntext".to_string());
         properties.insert("keep.name".to_string(), "norm".to_string());
         let merger = Merge::default();
-        assert_eq!(merger.manipulate_corpus(&mut g, &properties, None).is_ok(), true);
+        assert_eq!(
+            merger.manipulate_corpus(&mut g, &properties, None).is_ok(),
+            true
+        );
         let tmp_file = tempfile()?;
-        let export = graphannis_core::graph::serialization::graphml::export(&g, None, tmp_file, |_| {});
+        let export =
+            graphannis_core::graph::serialization::graphml::export(&g, None, tmp_file, |_| {});
         assert_eq!(export.is_ok(), true, "Export fails: {:?}", &export);
         Ok(())
     }
@@ -634,212 +854,324 @@ mod tests {
     fn input_graph(on_disk: bool) -> Result<AnnotationGraph> {
         let mut g = AnnotationGraph::new(on_disk)?;
         let mut u = GraphUpdate::default();
-        u.add_event(UpdateEvent::AddNode { node_name: "root".to_string(), node_type: "corpus".to_string() })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
         // import 1
-        u.add_event(UpdateEvent::AddNode { node_name: "root/a".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/a".to_string(), 
-                                           target_node: "root".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;
-        u.add_event(UpdateEvent::AddNode { node_name: "root/a/doc".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/a/doc".to_string(), 
-                                           target_node: "root/a".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;
-        for i in 0 .. 5 {
-            u.add_event(UpdateEvent::AddNode { node_name: format!("root/a/doc#t{}", i), node_type: "node".to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: format!("root/a/doc#t{}", i), 
-                                                    anno_ns: ANNIS_NS.to_string(), 
-                                                    anno_name: "tok".to_string(), 
-                                                    anno_value: " ".to_string() })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/a".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/a".to_string(),
+            target_node: "root".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/a/doc".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/a/doc".to_string(),
+            target_node: "root/a".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
+        for i in 0..5 {
+            u.add_event(UpdateEvent::AddNode {
+                node_name: format!("root/a/doc#t{}", i),
+                node_type: "node".to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: format!("root/a/doc#t{}", i),
+                anno_ns: ANNIS_NS.to_string(),
+                anno_name: "tok".to_string(),
+                anno_value: " ".to_string(),
+            })?;
             if i > 1 {
-                u.add_event(UpdateEvent::AddEdge { source_node: format!("root/a/doc#t{}", i - 1), 
-                                                   target_node: format!("root/a/doc#t{}", i), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Ordering.to_string(), 
-                                                   component_name: "".to_string() })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: format!("root/a/doc#t{}", i - 1),
+                    target_node: format!("root/a/doc#t{}", i),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Ordering.to_string(),
+                    component_name: "".to_string(),
+                })?;
             }
         }
         // fake-tok 1
         let sentence_span_name = "root/a/doc#s0";
-        u.add_event(UpdateEvent::AddNode { node_name: sentence_span_name.to_string(), node_type: "node".to_string() })?;
-        u.add_event(UpdateEvent::AddNodeLabel { node_name: sentence_span_name.to_string(), 
-                                                anno_ns: "dipl".to_string(),
-                                                anno_name: "sentence".to_string(), 
-                                                anno_value: "1".to_string() })?;
-        for (ii, (txt, start, end)) in [("I'm", 0, 2), 
-                                                  ("in", 2, 3), 
-                                                  ("New", 3, 4), 
-                                                  ("York", 4, 5)].iter().enumerate() {
+        u.add_event(UpdateEvent::AddNode {
+            node_name: sentence_span_name.to_string(),
+            node_type: "node".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddNodeLabel {
+            node_name: sentence_span_name.to_string(),
+            anno_ns: "dipl".to_string(),
+            anno_name: "sentence".to_string(),
+            anno_value: "1".to_string(),
+        })?;
+        for (ii, (txt, start, end)) in [("I'm", 0, 2), ("in", 2, 3), ("New", 3, 4), ("York", 4, 5)]
+            .iter()
+            .enumerate()
+        {
             let i = ii + 1;
             let name = format!("root/a/doc#s{}", i);
-            u.add_event(UpdateEvent::AddNode { node_name: name.to_string(), node_type: "node".to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: ANNIS_NS.to_string(), 
-                                                    anno_name: "tok".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: "dipl".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddEdge { source_node: sentence_span_name.to_string(),
-                                               target_node: name.to_string(),
-                                               layer: ANNIS_NS.to_string(), 
-                                               component_type: AnnotationComponentType::Coverage.to_string(), 
-                                               component_name: "".to_string() })?;
-            for j in *start .. *end {
-                u.add_event(UpdateEvent::AddEdge { source_node: name.to_string(), 
-                                                   target_node: format!("root/a/doc#t{}", j), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Coverage.to_string(), 
-                                                   component_name: "".to_string() })?;
+            u.add_event(UpdateEvent::AddNode {
+                node_name: name.to_string(),
+                node_type: "node".to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: ANNIS_NS.to_string(),
+                anno_name: "tok".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: "dipl".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddEdge {
+                source_node: sentence_span_name.to_string(),
+                target_node: name.to_string(),
+                layer: ANNIS_NS.to_string(),
+                component_type: AnnotationComponentType::Coverage.to_string(),
+                component_name: "".to_string(),
+            })?;
+            for j in *start..*end {
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: name.to_string(),
+                    target_node: format!("root/a/doc#t{}", j),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Coverage.to_string(),
+                    component_name: "".to_string(),
+                })?;
             }
             if i > 1 {
-                u.add_event(UpdateEvent::AddEdge { source_node: format!("root/a/doc#s{}", i - 1), 
-                                                   target_node: name.to_string(), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Ordering.to_string(), 
-                                                   component_name: "dipl".to_string() })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: format!("root/a/doc#s{}", i - 1),
+                    target_node: name.to_string(),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Ordering.to_string(),
+                    component_name: "dipl".to_string(),
+                })?;
             }
         }
         // fake-tok 2
-        for (ii, (txt, start, end, pos_label)) in [("I", 0, 1, "PRON"), 
-                                                  ("am", 1, 2, "VERB"), 
-                                                  ("in", 2, 3, "ADP"), 
-                                                  ("New York", 3, 5, "PROPN")].iter().enumerate() {
+        for (ii, (txt, start, end, pos_label)) in [
+            ("I", 0, 1, "PRON"),
+            ("am", 1, 2, "VERB"),
+            ("in", 2, 3, "ADP"),
+            ("New York", 3, 5, "PROPN"),
+        ]
+        .iter()
+        .enumerate()
+        {
             let i = ii + 5;
             let name = format!("root/a/doc#s{}", i);
-            u.add_event(UpdateEvent::AddNode { node_name: name.to_string(), node_type: "node".to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: ANNIS_NS.to_string(), 
-                                                    anno_name: "tok".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: "norm".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "norm".to_string(), 
-                                                    anno_name: "pos".to_string(), 
-                                                    anno_value: pos_label.to_string() })?;
-            for j in *start .. *end {
-                u.add_event(UpdateEvent::AddEdge { source_node: name.to_string(), 
-                                                   target_node: format!("root/a/doc#t{}", j), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Coverage.to_string(), 
-                                                   component_name: "".to_string() })?;
+            u.add_event(UpdateEvent::AddNode {
+                node_name: name.to_string(),
+                node_type: "node".to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: ANNIS_NS.to_string(),
+                anno_name: "tok".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: "norm".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "norm".to_string(),
+                anno_name: "pos".to_string(),
+                anno_value: pos_label.to_string(),
+            })?;
+            for j in *start..*end {
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: name.to_string(),
+                    target_node: format!("root/a/doc#t{}", j),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Coverage.to_string(),
+                    component_name: "".to_string(),
+                })?;
             }
             if ii > 0 {
-                u.add_event(UpdateEvent::AddEdge { source_node: format!("root/a/doc#s{}", i - 1), 
-                                                   target_node: name.to_string(), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Ordering.to_string(), 
-                                                   component_name: "norm".to_string() })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: format!("root/a/doc#s{}", i - 1),
+                    target_node: name.to_string(),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Ordering.to_string(),
+                    component_name: "norm".to_string(),
+                })?;
             }
         }
         // import 2
-        u.add_event(UpdateEvent::AddNode { node_name: "root/b".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/b".to_string(), 
-                                           target_node: "root".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;
-        u.add_event(UpdateEvent::AddNode { node_name: "root/b/doc".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/b/doc".to_string(), 
-                                           target_node: "root/b".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;
-        for (ii, (txt, lemma_label)) in [("I", "I"), 
-                                                  ("NOISE", "NOISE"),
-                                                  ("am", "be"), 
-                                                  ("in", "in"), 
-                                                  ("New York", "New York")].iter().enumerate() {
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/b".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/b".to_string(),
+            target_node: "root".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/b/doc".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/b/doc".to_string(),
+            target_node: "root/b".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
+        for (ii, (txt, lemma_label)) in [
+            ("I", "I"),
+            ("NOISE", "NOISE"),
+            ("am", "be"),
+            ("in", "in"),
+            ("New York", "New York"),
+        ]
+        .iter()
+        .enumerate()
+        {
             let i = ii + 1;
             let name = format!("root/b/doc#t{}", i);
-            u.add_event(UpdateEvent::AddNode { node_name: name.to_string(), node_type: "node".to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: ANNIS_NS.to_string(), 
-                                                    anno_name: "tok".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: "text".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: "lemma".to_string(), 
-                                                    anno_value: lemma_label.to_string() })?;
+            u.add_event(UpdateEvent::AddNode {
+                node_name: name.to_string(),
+                node_type: "node".to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: ANNIS_NS.to_string(),
+                anno_name: "tok".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: "text".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: "lemma".to_string(),
+                anno_value: lemma_label.to_string(),
+            })?;
             if i > 1 {
-                u.add_event(UpdateEvent::AddEdge { source_node: format!("root/b/doc#t{}", i - 1), 
-                                                   target_node: name.to_string(), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Ordering.to_string(), 
-                                                   component_name: "text".to_string() })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: format!("root/b/doc#t{}", i - 1),
+                    target_node: name.to_string(),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Ordering.to_string(),
+                    component_name: "text".to_string(),
+                })?;
             }
         }
         let dep_layer_name = "syntax";
         let dep_comp_name = "dep";
         let deprel_name = "deprel";
-        for (source, target, label) in [(3, 1, "subj"),
-                                      (3, 4, "comp:pred"),
-                                      (4, 5, "comp:obj")].iter() {
+        for (source, target, label) in
+            [(3, 1, "subj"), (3, 4, "comp:pred"), (4, 5, "comp:obj")].iter()
+        {
             let source_name = format!("root/b/doc#t{}", source);
             let target_name = format!("root/b/doc#t{}", target);
-            u.add_event(UpdateEvent::AddEdge { source_node: source_name.to_string(), 
-                                               target_node: target_name.to_string(), 
-                                               layer: dep_layer_name.to_string(), 
-                                               component_type: AnnotationComponentType::Pointing.to_string(), 
-                                               component_name: dep_comp_name.to_string() })?;
-            u.add_event(UpdateEvent::AddEdgeLabel { source_node: source_name, 
-                                                    target_node: target_name, 
-                                                    layer: dep_layer_name.to_string(), 
-                                                    component_type: AnnotationComponentType::Pointing.to_string(), 
-                                                    component_name: dep_comp_name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: deprel_name.to_string(), 
-                                                    anno_value: label.to_string() })?;
+            u.add_event(UpdateEvent::AddEdge {
+                source_node: source_name.to_string(),
+                target_node: target_name.to_string(),
+                layer: dep_layer_name.to_string(),
+                component_type: AnnotationComponentType::Pointing.to_string(),
+                component_name: dep_comp_name.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddEdgeLabel {
+                source_node: source_name,
+                target_node: target_name,
+                layer: dep_layer_name.to_string(),
+                component_type: AnnotationComponentType::Pointing.to_string(),
+                component_name: dep_comp_name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: deprel_name.to_string(),
+                anno_value: label.to_string(),
+            })?;
         }
         // import 3
-        u.add_event(UpdateEvent::AddNode { node_name: "root/c".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/c".to_string(), 
-                                           target_node: "root".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;
-        u.add_event(UpdateEvent::AddNode { node_name: "root/c/doc".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/c/doc".to_string(), 
-                                           target_node: "root/c".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;
-        for (ii, (txt, lemma_label)) in [("I", "I"), 
-                                                  ("am", "be"), 
-                                                  ("in", "in"), 
-                                                  ("New York", "New York")].iter().enumerate() {
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/c".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/c".to_string(),
+            target_node: "root".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/c/doc".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/c/doc".to_string(),
+            target_node: "root/c".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
+        for (ii, (txt, lemma_label)) in [
+            ("I", "I"),
+            ("am", "be"),
+            ("in", "in"),
+            ("New York", "New York"),
+        ]
+        .iter()
+        .enumerate()
+        {
             let i = ii + 1;
             let name = format!("root/c/doc#t{}", i);
-            u.add_event(UpdateEvent::AddNode { node_name: name.to_string(), node_type: "node".to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: ANNIS_NS.to_string(), 
-                                                    anno_name: "tok".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: "syntext".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: "lemma".to_string(), 
-                                                    anno_value: lemma_label.to_string() })?;
+            u.add_event(UpdateEvent::AddNode {
+                node_name: name.to_string(),
+                node_type: "node".to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: ANNIS_NS.to_string(),
+                anno_name: "tok".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: "syntext".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: "lemma".to_string(),
+                anno_value: lemma_label.to_string(),
+            })?;
             if i > 1 {
-                u.add_event(UpdateEvent::AddEdge { source_node: format!("root/c/doc#t{}", i - 1), 
-                                                   target_node: name.to_string(), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Ordering.to_string(), 
-                                                   component_name: "syntext".to_string() })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: format!("root/c/doc#t{}", i - 1),
+                    target_node: name.to_string(),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Ordering.to_string(),
+                    component_name: "syntext".to_string(),
+                })?;
             }
         }
         let pp_struct_name = "root/c/doc#structpp";
@@ -849,22 +1181,44 @@ mod tests {
         let anno_name = "cat";
         let syn_anno_layer_name = "syntax";
         let syn_component_name = "constituents";
-        for (node_id, label, targets) in [(sbj_struct_name, "sbj", ["root/c/doc#t1"].to_vec()),
-                                                                    (pp_struct_name, "pp", ["root/c/doc#t3", "root/c/doc#t4"].to_vec()),
-                                                                    (vp_struct_name, "vp", ["root/c/doc#t2", pp_struct_name].to_vec()),
-                                                                    (cp_struct_name, "cp", [sbj_struct_name, vp_struct_name].to_vec())].iter() {
-            u.add_event(UpdateEvent::AddNode { node_name: node_id.to_string(), 
-                                               node_type: "node".to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: node_id.to_string(),
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: anno_name.to_string(), 
-                                                    anno_value: label.to_string() })?;
+        for (node_id, label, targets) in [
+            (sbj_struct_name, "sbj", ["root/c/doc#t1"].to_vec()),
+            (
+                pp_struct_name,
+                "pp",
+                ["root/c/doc#t3", "root/c/doc#t4"].to_vec(),
+            ),
+            (
+                vp_struct_name,
+                "vp",
+                ["root/c/doc#t2", pp_struct_name].to_vec(),
+            ),
+            (
+                cp_struct_name,
+                "cp",
+                [sbj_struct_name, vp_struct_name].to_vec(),
+            ),
+        ]
+        .iter()
+        {
+            u.add_event(UpdateEvent::AddNode {
+                node_name: node_id.to_string(),
+                node_type: "node".to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: node_id.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: anno_name.to_string(),
+                anno_value: label.to_string(),
+            })?;
             for target in targets.into_iter() {
-                u.add_event(UpdateEvent::AddEdge { source_node: node_id.to_string(), 
-                                                   target_node: target.to_string(), 
-                                                   layer: syn_anno_layer_name.to_string(), 
-                                                   component_type: AnnotationComponentType::Dominance.to_string(), 
-                                                   component_name: syn_component_name.to_string() })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: node_id.to_string(),
+                    target_node: target.to_string(),
+                    layer: syn_anno_layer_name.to_string(),
+                    component_type: AnnotationComponentType::Dominance.to_string(),
+                    component_name: syn_component_name.to_string(),
+                })?;
             }
         }
         g.apply_update(&mut u, |_msg| {})?;
@@ -874,167 +1228,249 @@ mod tests {
     fn expected_output_graph(on_disk: bool) -> Result<AnnotationGraph> {
         let mut g = AnnotationGraph::new(on_disk)?;
         let mut u = GraphUpdate::default();
-        u.add_event(UpdateEvent::AddNode { node_name: "root".to_string(), node_type: "corpus".to_string() })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
         // import 1
-        u.add_event(UpdateEvent::AddNode { node_name: "root/a".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/a".to_string(), 
-                                           target_node: "root".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;
-        u.add_event(UpdateEvent::AddNode { node_name: "root/a/doc".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/a/doc".to_string(), 
-                                           target_node: "root/a".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;
-        for i in 0 .. 5 {
-            u.add_event(UpdateEvent::AddNode { node_name: format!("root/a/doc#t{}", i), node_type: "node".to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: format!("root/a/doc#t{}", i), 
-                                                    anno_ns: ANNIS_NS.to_string(), 
-                                                    anno_name: "tok".to_string(), 
-                                                    anno_value: " ".to_string() })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/a".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/a".to_string(),
+            target_node: "root".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/a/doc".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/a/doc".to_string(),
+            target_node: "root/a".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
+        for i in 0..5 {
+            u.add_event(UpdateEvent::AddNode {
+                node_name: format!("root/a/doc#t{}", i),
+                node_type: "node".to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: format!("root/a/doc#t{}", i),
+                anno_ns: ANNIS_NS.to_string(),
+                anno_name: "tok".to_string(),
+                anno_value: " ".to_string(),
+            })?;
             if i > 1 {
-                u.add_event(UpdateEvent::AddEdge { source_node: format!("root/a/doc#t{}", i - 1), 
-                                                   target_node: format!("root/a/doc#t{}", i), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Ordering.to_string(), 
-                                                   component_name: "".to_string() })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: format!("root/a/doc#t{}", i - 1),
+                    target_node: format!("root/a/doc#t{}", i),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Ordering.to_string(),
+                    component_name: "".to_string(),
+                })?;
             }
         }
         // fake-tok 1
         let sentence_span_name = "root/a/doc#s0";
-        u.add_event(UpdateEvent::AddNode { node_name: sentence_span_name.to_string(), node_type: "node".to_string() })?;
-        u.add_event(UpdateEvent::AddNodeLabel { node_name: sentence_span_name.to_string(), 
-                                                anno_ns: "dipl".to_string(),
-                                                anno_name: "sentence".to_string(), 
-                                                anno_value: "1".to_string() })?;
-        for (ii, (txt, start, end)) in [("I'm", 0, 2), 
-                                                  ("in", 2, 3), 
-                                                  ("New", 3, 4), 
-                                                  ("York", 4, 5)].iter().enumerate() {
+        u.add_event(UpdateEvent::AddNode {
+            node_name: sentence_span_name.to_string(),
+            node_type: "node".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddNodeLabel {
+            node_name: sentence_span_name.to_string(),
+            anno_ns: "dipl".to_string(),
+            anno_name: "sentence".to_string(),
+            anno_value: "1".to_string(),
+        })?;
+        for (ii, (txt, start, end)) in [("I'm", 0, 2), ("in", 2, 3), ("New", 3, 4), ("York", 4, 5)]
+            .iter()
+            .enumerate()
+        {
             let i = ii + 1;
             let name = format!("root/a/doc#s{}", i);
-            u.add_event(UpdateEvent::AddNode { node_name: name.to_string(), node_type: "node".to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: ANNIS_NS.to_string(), 
-                                                    anno_name: "tok".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: "dipl".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddEdge { source_node: sentence_span_name.to_string(),
-                                               target_node: name.to_string(),
-                                               layer: ANNIS_NS.to_string(), 
-                                               component_type: AnnotationComponentType::Coverage.to_string(), 
-                                               component_name: "".to_string() })?;
-            for j in *start .. *end {
-                u.add_event(UpdateEvent::AddEdge { source_node: name.to_string(), 
-                                                   target_node: format!("root/a/doc#t{}", j), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Coverage.to_string(), 
-                                                   component_name: "".to_string() })?;
+            u.add_event(UpdateEvent::AddNode {
+                node_name: name.to_string(),
+                node_type: "node".to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: ANNIS_NS.to_string(),
+                anno_name: "tok".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: "dipl".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddEdge {
+                source_node: sentence_span_name.to_string(),
+                target_node: name.to_string(),
+                layer: ANNIS_NS.to_string(),
+                component_type: AnnotationComponentType::Coverage.to_string(),
+                component_name: "".to_string(),
+            })?;
+            for j in *start..*end {
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: name.to_string(),
+                    target_node: format!("root/a/doc#t{}", j),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Coverage.to_string(),
+                    component_name: "".to_string(),
+                })?;
             }
             if i > 1 {
-                u.add_event(UpdateEvent::AddEdge { source_node: format!("root/a/doc#s{}", i - 1), 
-                                                   target_node: name.to_string(), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Ordering.to_string(), 
-                                                   component_name: "dipl".to_string() })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: format!("root/a/doc#s{}", i - 1),
+                    target_node: name.to_string(),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Ordering.to_string(),
+                    component_name: "dipl".to_string(),
+                })?;
             }
         }
         // fake-tok 2
-        for (ii, (txt, start, end, pos_label)) in [("I", 0, 1, "PRON"), 
-                                                  ("am", 1, 2, "VERB"), 
-                                                  ("in", 2, 3, "ADP"), 
-                                                  ("New York", 3, 5, "PROPN")].iter().enumerate() {
+        for (ii, (txt, start, end, pos_label)) in [
+            ("I", 0, 1, "PRON"),
+            ("am", 1, 2, "VERB"),
+            ("in", 2, 3, "ADP"),
+            ("New York", 3, 5, "PROPN"),
+        ]
+        .iter()
+        .enumerate()
+        {
             let i = ii + 5;
             let name = format!("root/a/doc#s{}", i);
-            u.add_event(UpdateEvent::AddNode { node_name: name.to_string(), node_type: "node".to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: ANNIS_NS.to_string(), 
-                                                    anno_name: "tok".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: "norm".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "norm".to_string(), 
-                                                    anno_name: "pos".to_string(), 
-                                                    anno_value: pos_label.to_string() })?;
-            for j in *start .. *end {
-                u.add_event(UpdateEvent::AddEdge { source_node: name.to_string(), 
-                                                   target_node: format!("root/a/doc#t{}", j), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Coverage.to_string(), 
-                                                   component_name: "".to_string() })?;
+            u.add_event(UpdateEvent::AddNode {
+                node_name: name.to_string(),
+                node_type: "node".to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: ANNIS_NS.to_string(),
+                anno_name: "tok".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: "norm".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "norm".to_string(),
+                anno_name: "pos".to_string(),
+                anno_value: pos_label.to_string(),
+            })?;
+            for j in *start..*end {
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: name.to_string(),
+                    target_node: format!("root/a/doc#t{}", j),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Coverage.to_string(),
+                    component_name: "".to_string(),
+                })?;
             }
             if ii > 1 {
-                u.add_event(UpdateEvent::AddEdge { source_node: format!("root/a/doc#s{}", i - 1), 
-                                                   target_node: name.to_string(), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Ordering.to_string(), 
-                                                   component_name: "norm".to_string() })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: format!("root/a/doc#s{}", i - 1),
+                    target_node: name.to_string(),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Ordering.to_string(),
+                    component_name: "norm".to_string(),
+                })?;
             }
         }
         // import 2 (after merge)
-        u.add_event(UpdateEvent::AddNode { node_name: "root/b".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/b".to_string(), 
-                                           target_node: "root".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;
-        u.add_event(UpdateEvent::AddNode { node_name: "root/b/doc".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/b/doc".to_string(), 
-                                           target_node: "root/b".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/b".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/b".to_string(),
+            target_node: "root".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/b/doc".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/b/doc".to_string(),
+            target_node: "root/b".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
         for (ii, lemma_label) in ["I", "be", "in", "New York"].iter().enumerate() {
             let i = ii + 5;
             let name = format!("root/a/doc#s{}", i);
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: "lemma".to_string(), 
-                                                    anno_value: lemma_label.to_string() })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: "lemma".to_string(),
+                anno_value: lemma_label.to_string(),
+            })?;
         }
         let dep_layer_name = "syntax";
         let dep_comp_name = "dep";
         let deprel_name = "deprel";
-        for (source, target, label) in [(6, 5, "subj"),
-                                      (6, 7, "comp:pred"),
-                                      (7, 8, "comp:obj")].iter() {
+        for (source, target, label) in
+            [(6, 5, "subj"), (6, 7, "comp:pred"), (7, 8, "comp:obj")].iter()
+        {
             let source_name = format!("root/a/doc#s{}", source);
             let target_name = format!("root/a/doc#s{}", target);
-            u.add_event(UpdateEvent::AddEdge { source_node: source_name.to_string(), 
-                                               target_node: target_name.to_string(), 
-                                               layer: dep_layer_name.to_string(), 
-                                               component_type: AnnotationComponentType::Pointing.to_string(), 
-                                               component_name: dep_comp_name.to_string() })?;
-            u.add_event(UpdateEvent::AddEdgeLabel { source_node: source_name, 
-                                                    target_node: target_name, 
-                                                    layer: dep_layer_name.to_string(), 
-                                                    component_type: AnnotationComponentType::Pointing.to_string(), 
-                                                    component_name: dep_comp_name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: deprel_name.to_string(), 
-                                                    anno_value: label.to_string() })?;
+            u.add_event(UpdateEvent::AddEdge {
+                source_node: source_name.to_string(),
+                target_node: target_name.to_string(),
+                layer: dep_layer_name.to_string(),
+                component_type: AnnotationComponentType::Pointing.to_string(),
+                component_name: dep_comp_name.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddEdgeLabel {
+                source_node: source_name,
+                target_node: target_name,
+                layer: dep_layer_name.to_string(),
+                component_type: AnnotationComponentType::Pointing.to_string(),
+                component_name: dep_comp_name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: deprel_name.to_string(),
+                anno_value: label.to_string(),
+            })?;
         }
         // import 3 (after merge)
-        u.add_event(UpdateEvent::AddNode { node_name: "root/c".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/c".to_string(), 
-                                           target_node: "root".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;
-        u.add_event(UpdateEvent::AddNode { node_name: "root/c/doc".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/c/doc".to_string(), 
-                                           target_node: "root/c".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;        
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/c".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/c".to_string(),
+            target_node: "root".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/c/doc".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/c/doc".to_string(),
+            target_node: "root/c".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
         let pp_struct_name = "root/c/doc#structpp";
         let sbj_struct_name = "root/c/doc#structsbj";
         let vp_struct_name = "root/c/doc#structvp";
@@ -1042,26 +1478,47 @@ mod tests {
         let anno_name = "cat";
         let syn_anno_layer_name = "syntax";
         let syn_component_name = "constituents";
-        for (node_id, label, targets) in [(sbj_struct_name, "sbj", ["root/a/doc#s1"].to_vec()),
-                                                                    (pp_struct_name, "pp", ["root/a/doc#s3", "root/a/doc#s4"].to_vec()),
-                                                                    (vp_struct_name, "vp", ["root/a/doc#s2", pp_struct_name].to_vec()),
-                                                                    (cp_struct_name, "cp", [sbj_struct_name, vp_struct_name].to_vec())].iter() {
-            u.add_event(UpdateEvent::AddNode { node_name: node_id.to_string(), 
-                                               node_type: "node".to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: node_id.to_string(),
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: anno_name.to_string(), 
-                                                    anno_value: label.to_string() })?;
+        for (node_id, label, targets) in [
+            (sbj_struct_name, "sbj", ["root/a/doc#s1"].to_vec()),
+            (
+                pp_struct_name,
+                "pp",
+                ["root/a/doc#s3", "root/a/doc#s4"].to_vec(),
+            ),
+            (
+                vp_struct_name,
+                "vp",
+                ["root/a/doc#s2", pp_struct_name].to_vec(),
+            ),
+            (
+                cp_struct_name,
+                "cp",
+                [sbj_struct_name, vp_struct_name].to_vec(),
+            ),
+        ]
+        .iter()
+        {
+            u.add_event(UpdateEvent::AddNode {
+                node_name: node_id.to_string(),
+                node_type: "node".to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: node_id.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: anno_name.to_string(),
+                anno_value: label.to_string(),
+            })?;
             for target in targets.into_iter() {
-                u.add_event(UpdateEvent::AddEdge { source_node: node_id.to_string(), 
-                                                   target_node: target.to_string(), 
-                                                   layer: syn_anno_layer_name.to_string(), 
-                                                   component_type: AnnotationComponentType::Dominance.to_string(), 
-                                                   component_name: syn_component_name.to_string() })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: node_id.to_string(),
+                    target_node: target.to_string(),
+                    layer: syn_anno_layer_name.to_string(),
+                    component_type: AnnotationComponentType::Dominance.to_string(),
+                    component_name: syn_component_name.to_string(),
+                })?;
             }
         }
         g.apply_update(&mut u, |_msg| {})?;
         Ok(g)
     }
-
 }

--- a/src/manipulator/re.rs
+++ b/src/manipulator/re.rs
@@ -1,11 +1,20 @@
 use std::{cmp::Ordering, collections::BTreeSet};
 
-use graphannis::{AnnotationGraph, update::{GraphUpdate, UpdateEvent}, graph::{Edge, AnnoKey, Match}, model::{AnnotationComponentType, AnnotationComponent}};
-use graphannis_core::{annostorage::ValueSearch, graph::{NODE_NAME_KEY, ANNIS_NS}, dfs::CycleSafeDFS};
+use graphannis::{
+    graph::{AnnoKey, Edge, Match},
+    model::{AnnotationComponent, AnnotationComponentType},
+    update::{GraphUpdate, UpdateEvent},
+    AnnotationGraph,
+};
 use graphannis_core::util::split_qname;
+use graphannis_core::{
+    annostorage::ValueSearch,
+    dfs::CycleSafeDFS,
+    graph::{ANNIS_NS, NODE_NAME_KEY},
+};
 use itertools::Itertools;
 
-use crate::{Manipulator, Module, error::AnnattoError};
+use crate::{error::AnnattoError, Manipulator, Module};
 
 pub struct Replace {}
 
@@ -30,100 +39,165 @@ const PROP_MOVE: &str = "move.node.annos";
 const PROPVAL_SEP: &str = ",";
 const PROPVAL_OLD_NEW_SEP: &str = ":=";
 
-fn remove_nodes(update: &mut GraphUpdate, names: Vec<&str>) -> Result<(), Box<dyn std::error::Error>> {
+fn remove_nodes(
+    update: &mut GraphUpdate,
+    names: Vec<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
     for name in names {
-        update.add_event(UpdateEvent::DeleteNode { node_name: name.to_string() })?;
+        update.add_event(UpdateEvent::DeleteNode {
+            node_name: name.to_string(),
+        })?;
     }
     Ok(())
 }
 
-fn place_at_new_target(graph: &AnnotationGraph,
-                       update: &mut GraphUpdate,
-                       m: &Match,
-                       target_key: &AnnoKey) -> Result<(), Box<dyn std::error::Error>> {                            
-    let coverage_component = AnnotationComponent::new(AnnotationComponentType::Coverage, ANNIS_NS.into(), "".into());
-    let coverage_storage = graph.get_graphstorage(&coverage_component).unwrap();    
-    let order_component = AnnotationComponent::new(AnnotationComponentType::Ordering, ANNIS_NS.to_string().into(), target_key.ns.clone());
+fn place_at_new_target(
+    graph: &AnnotationGraph,
+    update: &mut GraphUpdate,
+    m: &Match,
+    target_key: &AnnoKey,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let coverage_component = AnnotationComponent::new(
+        AnnotationComponentType::Coverage,
+        ANNIS_NS.into(),
+        "".into(),
+    );
+    let coverage_storage = graph.get_graphstorage(&coverage_component).unwrap();
+    let order_component = AnnotationComponent::new(
+        AnnotationComponentType::Ordering,
+        ANNIS_NS.to_string().into(),
+        target_key.ns.clone(),
+    );
     let order_storage = graph.get_graphstorage(&order_component).unwrap();
     let source_node = m.node;
     let mut covered_terminal_nodes = Vec::new();
-    CycleSafeDFS::new(coverage_storage.as_edgecontainer(), 
-                      source_node.into(),
-                      1, 
-                      usize::MAX)
+    CycleSafeDFS::new(
+        coverage_storage.as_edgecontainer(),
+        source_node.into(),
+        1,
+        usize::MAX,
+    )
     .into_iter()
     .map(|r| r.unwrap().node.clone())
     .filter(|n| !coverage_storage.has_outgoing_edges(*n).unwrap())
-    .for_each(|n|covered_terminal_nodes.push(n));
+    .for_each(|n| covered_terminal_nodes.push(n));
     let mut covering_nodes = BTreeSet::new();
     for terminal in covered_terminal_nodes {
-        for reachable in CycleSafeDFS::new_inverse(coverage_storage.as_edgecontainer(), terminal, 1, usize::MAX) {
-            let covering_node = reachable?.node;            
-            let is_part_of_ordering = order_storage.has_outgoing_edges(covering_node)? || order_storage.get_ingoing_edges(covering_node).count() > 0;
-            if is_part_of_ordering {                       
+        for reachable in
+            CycleSafeDFS::new_inverse(coverage_storage.as_edgecontainer(), terminal, 1, usize::MAX)
+        {
+            let covering_node = reachable?.node;
+            let is_part_of_ordering = order_storage.has_outgoing_edges(covering_node)?
+                || order_storage.get_ingoing_edges(covering_node).count() > 0;
+            if is_part_of_ordering {
                 covering_nodes.insert(covering_node);
             }
         }
     }
     let node_annos = graph.get_node_annos();
-    let anno_value = node_annos.get_value_for_item(&m.node, &m.anno_key)?.unwrap();    
+    let anno_value = node_annos
+        .get_value_for_item(&m.node, &m.anno_key)?
+        .unwrap();
     match covering_nodes.len().partial_cmp(&1) {
         Some(Ordering::Equal) => {
-            let target_name = node_annos.get_value_for_item(&covering_nodes.pop_last().unwrap(), &NODE_NAME_KEY)?.unwrap();
-            update.add_event(UpdateEvent::AddNodeLabel { node_name: target_name.to_string(), anno_ns: target_key.ns.to_string(), anno_name: target_key.name.to_string(), anno_value: anno_value.to_string() })?;
-        },
+            let target_name = node_annos
+                .get_value_for_item(&covering_nodes.pop_last().unwrap(), &NODE_NAME_KEY)?
+                .unwrap();
+            update.add_event(UpdateEvent::AddNodeLabel {
+                node_name: target_name.to_string(),
+                anno_ns: target_key.ns.to_string(),
+                anno_name: target_key.name.to_string(),
+                anno_value: anno_value.to_string(),
+            })?;
+        }
         Some(Ordering::Greater) => {
-            // create new span first (we could also check for an exiting one, but it sounds expensive and not promising)    
+            // create new span first (we could also check for an exiting one, but it sounds expensive and not promising)
             let probe_node = covering_nodes.pop_last().unwrap();
-            let doc_name = node_annos.get_value_for_item(&probe_node, &NODE_NAME_KEY)?.unwrap().rsplit_once("#").unwrap().0.to_string();
+            let doc_name = node_annos
+                .get_value_for_item(&probe_node, &NODE_NAME_KEY)?
+                .unwrap()
+                .rsplit_once("#")
+                .unwrap()
+                .0
+                .to_string();
             covering_nodes.insert(probe_node);
             let node_name_pref = format!("{}#sSpan", doc_name);
-            let existing = node_annos.get_all_values(&NODE_NAME_KEY, false)?
-                                    .iter()
-                                    .filter(|v| v.starts_with(node_name_pref.as_str()))
-                                    .collect_vec().len();
+            let existing = node_annos
+                .get_all_values(&NODE_NAME_KEY, false)?
+                .iter()
+                .filter(|v| v.starts_with(node_name_pref.as_str()))
+                .collect_vec()
+                .len();
             let span_name = format!("{}{}", node_name_pref, existing + 1);
-            update.add_event(UpdateEvent::AddNode { node_name: span_name.clone(), node_type: "node".to_string() })?;
-            update.add_event(UpdateEvent::AddNodeLabel { node_name: span_name.clone(), anno_ns: target_key.ns.to_string(), anno_name: target_key.name.to_string(), anno_value: anno_value.to_string() })?;            
+            update.add_event(UpdateEvent::AddNode {
+                node_name: span_name.clone(),
+                node_type: "node".to_string(),
+            })?;
+            update.add_event(UpdateEvent::AddNodeLabel {
+                node_name: span_name.clone(),
+                anno_ns: target_key.ns.to_string(),
+                anno_name: target_key.name.to_string(),
+                anno_value: anno_value.to_string(),
+            })?;
             for member in covering_nodes {
-                let member_name = node_annos.get_value_for_item(&member, &NODE_NAME_KEY)?.unwrap();
-                update.add_event(UpdateEvent::AddEdge { source_node: span_name.clone(), 
-                                                        target_node: member_name.to_string(), 
-                                                        layer: ANNIS_NS.to_string(), 
-                                                        component_type: AnnotationComponentType::Coverage.to_string(), 
-                                                        component_name: "".to_string() })?;
-            }        
-        },
+                let member_name = node_annos
+                    .get_value_for_item(&member, &NODE_NAME_KEY)?
+                    .unwrap();
+                update.add_event(UpdateEvent::AddEdge {
+                    source_node: span_name.clone(),
+                    target_node: member_name.to_string(),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Coverage.to_string(),
+                    component_name: "".to_string(),
+                })?;
+            }
+        }
         _ => {
-            let message = format!("Could not gather any covered nodes for name `{}`", target_key.ns);
-            let err = AnnattoError::Manipulator { reason: message, manipulator: MODULE_NAME.to_string() };
+            let message = format!(
+                "Could not gather any covered nodes for name `{}`",
+                target_key.ns
+            );
+            let err = AnnattoError::Manipulator {
+                reason: message,
+                manipulator: MODULE_NAME.to_string(),
+            };
             return Err(Box::new(err));
-        },
+        }
     };
     Ok(())
 }
 
-fn replace_node_annos(graph: &mut AnnotationGraph,
-                      update: &mut GraphUpdate, 
-                      anno_keys: Vec<(AnnoKey, Option<AnnoKey>)>, 
-                      move_by_ns: bool) -> Result<(), Box<dyn std::error::Error>> {
+fn replace_node_annos(
+    graph: &mut AnnotationGraph,
+    update: &mut GraphUpdate,
+    anno_keys: Vec<(AnnoKey, Option<AnnoKey>)>,
+    move_by_ns: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     let annos = graph.get_node_annos();
     for (old_key, new_key_opt) in anno_keys.into_iter() {
-        for r in annos.exact_anno_search(ns_from_key(&old_key), old_key.name.as_str(), ValueSearch::Any) {
+        for r in annos.exact_anno_search(
+            ns_from_key(&old_key),
+            old_key.name.as_str(),
+            ValueSearch::Any,
+        ) {
             let m = r?;
             let node_name = annos.get_value_for_item(&m.node, &NODE_NAME_KEY)?.unwrap();
-            update.add_event(UpdateEvent::DeleteNodeLabel { node_name: node_name.to_string(), 
-                                                            anno_ns: old_key.ns.to_string(), 
-                                                            anno_name: old_key.name.to_string() })?;
+            update.add_event(UpdateEvent::DeleteNodeLabel {
+                node_name: node_name.to_string(),
+                anno_ns: old_key.ns.to_string(),
+                anno_name: old_key.name.to_string(),
+            })?;
             if let Some(ref new_key) = new_key_opt {
                 if move_by_ns {
                     place_at_new_target(graph, update, &m, new_key)?;
                 } else {
                     let value = annos.get_value_for_item(&m.node, &old_key)?.unwrap();
-                    update.add_event(UpdateEvent::AddNodeLabel { node_name: node_name.to_string(), 
-                                                                 anno_ns: new_key.ns.to_string(), 
-                                                                 anno_name: new_key.name.to_string(), 
-                                                                 anno_value: value.to_string() })?;
+                    update.add_event(UpdateEvent::AddNodeLabel {
+                        node_name: node_name.to_string(),
+                        anno_ns: new_key.ns.to_string(),
+                        anno_name: new_key.name.to_string(),
+                        anno_value: value.to_string(),
+                    })?;
                 }
             }
         }
@@ -131,38 +205,60 @@ fn replace_node_annos(graph: &mut AnnotationGraph,
     Ok(())
 }
 
-fn replace_edge_annos(graph: &mut AnnotationGraph, 
-                      update: &mut GraphUpdate,
-                      anno_keys: Vec<(AnnoKey, Option<AnnoKey>)>) -> Result<(), Box<dyn std::error::Error>> {
+fn replace_edge_annos(
+    graph: &mut AnnotationGraph,
+    update: &mut GraphUpdate,
+    anno_keys: Vec<(AnnoKey, Option<AnnoKey>)>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let node_annos = graph.get_node_annos();
     for (old_key, new_key_opt) in anno_keys {
         for component in graph.get_all_components(None, None) {
-            let component_storage = graph.get_graphstorage(&component).unwrap();            
-            let edge_annos = component_storage.get_anno_storage();           
-            for r in edge_annos.exact_anno_search(ns_from_key(&old_key), old_key.name.as_str(), ValueSearch::Any) {
-                let m = r?;                
+            let component_storage = graph.get_graphstorage(&component).unwrap();
+            let edge_annos = component_storage.get_anno_storage();
+            for r in edge_annos.exact_anno_search(
+                ns_from_key(&old_key),
+                old_key.name.as_str(),
+                ValueSearch::Any,
+            ) {
+                let m = r?;
                 let source_node = m.node;
-                let source_node_name = node_annos.get_value_for_item(&source_node, &NODE_NAME_KEY)?.unwrap();
-                for out_edge_opt in component_storage.get_outgoing_edges(source_node) {                    
+                let source_node_name = node_annos
+                    .get_value_for_item(&source_node, &NODE_NAME_KEY)?
+                    .unwrap();
+                for out_edge_opt in component_storage.get_outgoing_edges(source_node) {
                     let target_node = out_edge_opt?;
-                    let target_node_name = node_annos.get_value_for_item(&target_node, &NODE_NAME_KEY)?.unwrap();
-                    update.add_event(UpdateEvent::DeleteEdgeLabel { source_node: source_node_name.to_string(), 
-                                                                    target_node: target_node_name.to_string(), 
-                                                                    layer: component.layer.to_string(), 
-                                                                    component_type: component.get_type().to_string(), 
-                                                                    component_name: component.name.to_string(), 
-                                                                    anno_ns: m.anno_key.ns.to_string(), 
-                                                                    anno_name: old_key.name.to_string() })?;
+                    let target_node_name = node_annos
+                        .get_value_for_item(&target_node, &NODE_NAME_KEY)?
+                        .unwrap();
+                    update.add_event(UpdateEvent::DeleteEdgeLabel {
+                        source_node: source_node_name.to_string(),
+                        target_node: target_node_name.to_string(),
+                        layer: component.layer.to_string(),
+                        component_type: component.get_type().to_string(),
+                        component_name: component.name.to_string(),
+                        anno_ns: m.anno_key.ns.to_string(),
+                        anno_name: old_key.name.to_string(),
+                    })?;
                     if let Some(ref new_key) = new_key_opt {
-                        let value = edge_annos.get_value_for_item(&Edge { source: source_node, target: target_node}, &m.anno_key)?.unwrap();
-                        update.add_event(UpdateEvent::AddEdgeLabel { source_node: source_node_name.to_string(), 
-                                                                     target_node: target_node_name.to_string(), 
-                                                                     layer: component.layer.to_string(), 
-                                                                     component_type: component.get_type().to_string(),
-                                                                     component_name: component.name.to_string(), 
-                                                                     anno_ns: new_key.ns.to_string(), 
-                                                                     anno_name: new_key.name.to_string(), 
-                                                                     anno_value: value.to_string() })?;
+                        let value = edge_annos
+                            .get_value_for_item(
+                                &Edge {
+                                    source: source_node,
+                                    target: target_node,
+                                },
+                                &m.anno_key,
+                            )?
+                            .unwrap();
+                        update.add_event(UpdateEvent::AddEdgeLabel {
+                            source_node: source_node_name.to_string(),
+                            target_node: target_node_name.to_string(),
+                            layer: component.layer.to_string(),
+                            component_type: component.get_type().to_string(),
+                            component_name: component.name.to_string(),
+                            anno_ns: new_key.ns.to_string(),
+                            anno_name: new_key.name.to_string(),
+                            anno_value: value.to_string(),
+                        })?;
                     }
                 }
             }
@@ -174,8 +270,14 @@ fn replace_edge_annos(graph: &mut AnnotationGraph,
 fn key_from_qname(qname: &str) -> AnnoKey {
     let (ns, name) = split_qname(qname);
     match ns {
-        None => AnnoKey { ns: "".into(), name: name.into() },
-        Some(ns_val) => AnnoKey {ns: ns_val.into(), name: name.into() }
+        None => AnnoKey {
+            ns: "".into(),
+            name: name.into(),
+        },
+        Some(ns_val) => AnnoKey {
+            ns: ns_val.into(),
+            name: name.into(),
+        },
     }
 }
 
@@ -187,15 +289,17 @@ fn ns_from_key<'a>(anno_key: &'a AnnoKey) -> Option<&'a str> {
     }
 }
 
-fn read_replace_property_value(value: &str) -> Result<Vec<(AnnoKey, Option<AnnoKey>)>, Box<dyn std::error::Error>> {
+fn read_replace_property_value(
+    value: &str,
+) -> Result<Vec<(AnnoKey, Option<AnnoKey>)>, Box<dyn std::error::Error>> {
     let mut names = Vec::new();
     for entry in value.split(PROPVAL_SEP) {
         let old_new = entry.split_once(PROPVAL_OLD_NEW_SEP);
         let key_and_opt = match old_new {
             None => {
                 // only old name, i. e. remove
-                (key_from_qname(entry), None)  
-            },
+                (key_from_qname(entry), None)
+            }
             Some(tpl) => {
                 // new name specified, too
                 (key_from_qname(tpl.0), Some(key_from_qname(tpl.1)))
@@ -216,13 +320,13 @@ impl Manipulator for Replace {
         let mut update = GraphUpdate::default();
         let move_by_ns = match properties.get(&PROP_MOVE.to_string()) {
             None => false,
-            Some(v) => v.parse::<bool>()?
+            Some(v) => v.parse::<bool>()?,
         };
-        if let Some(node_name_s ) = properties.get(&PROP_NODE_NAMES.to_string()) {
+        if let Some(node_name_s) = properties.get(&PROP_NODE_NAMES.to_string()) {
             let node_names = node_name_s.split(PROPVAL_SEP).collect_vec();
             remove_nodes(&mut update, node_names)?;
         }
-        if let Some(anno_name_s ) = properties.get(&PROP_NODE_ANNOS.to_string()) {
+        if let Some(anno_name_s) = properties.get(&PROP_NODE_ANNOS.to_string()) {
             let node_annos = read_replace_property_value(anno_name_s)?;
             replace_node_annos(graph, &mut update, node_annos, move_by_ns)?;
         }
@@ -240,40 +344,40 @@ mod tests {
     use std::collections::{BTreeMap, BTreeSet};
     use std::env::temp_dir;
 
-    use crate::Result;
-    use crate::manipulator::Manipulator;
     use crate::manipulator::re::Replace;
+    use crate::manipulator::Manipulator;
+    use crate::Result;
 
-    use graphannis::{AnnotationGraph,CorpusStorage};
-    use graphannis::corpusstorage::{QueryLanguage,ResultOrder,SearchQuery};
-    use graphannis_core::annostorage::ValueSearch;
+    use graphannis::corpusstorage::{QueryLanguage, ResultOrder, SearchQuery};
     use graphannis::model::AnnotationComponentType;
-    use graphannis::update::{GraphUpdate,UpdateEvent};
-    use graphannis_core::graph::{ANNIS_NS, NODE_TYPE_KEY, NODE_NAME_KEY};
+    use graphannis::update::{GraphUpdate, UpdateEvent};
+    use graphannis::{AnnotationGraph, CorpusStorage};
+    use graphannis_core::annostorage::ValueSearch;
+    use graphannis_core::graph::{ANNIS_NS, NODE_NAME_KEY, NODE_TYPE_KEY};
     use itertools::Itertools;
-    use tempfile::{tempfile, tempdir_in};
+    use tempfile::{tempdir_in, tempfile};
 
     #[test]
     fn test_remove_in_mem() {
-        let r = core_test(false, false); 
+        let r = core_test(false, false);
         assert_eq!(r.is_ok(), true, "Probing core test result {:?}", r);
     }
 
     #[test]
     fn test_remove_on_disk() {
-        let r = core_test(true, false); 
+        let r = core_test(true, false);
         assert_eq!(r.is_ok(), true, "Probing core test result {:?}", r);
     }
 
     #[test]
     fn test_rename_in_mem() {
-        let r = core_test(false, true); 
+        let r = core_test(false, true);
         assert_eq!(r.is_ok(), true, "Probing core test result {:?}", r);
     }
 
     #[test]
     fn test_rename_on_disk() {
-        let r = core_test(true, true); 
+        let r = core_test(true, true);
         assert_eq!(r.is_ok(), true, "Probing core test result {:?}", r);
     }
 
@@ -296,33 +400,63 @@ mod tests {
             expected_output_graph(on_disk)?
         };
         // corpus nodes
-        let e_corpus_nodes: BTreeSet<String> = e_g.get_node_annos()
-                                        .exact_anno_search(Some(&NODE_TYPE_KEY.ns), &NODE_TYPE_KEY.name, ValueSearch::Some("corpus"))
-                                        .into_iter()
-                                        .map(|r| r.unwrap().node)
-                                        .map(|id_| e_g.get_node_annos().get_value_for_item(&id_, &NODE_NAME_KEY).unwrap().unwrap().to_string())
-                                        .collect();
-        let g_corpus_nodes: BTreeSet<String> = g.get_node_annos()
-                                        .exact_anno_search(Some(&NODE_TYPE_KEY.ns), &NODE_TYPE_KEY.name, ValueSearch::Some("corpus"))
-                                        .into_iter()
-                                        .map(|r| r.unwrap().node)
-                                        .map(|id_| g.get_node_annos().get_value_for_item(&id_, &NODE_NAME_KEY).unwrap().unwrap().to_string())
-                                        .collect();
-        assert_eq!(e_corpus_nodes, g_corpus_nodes);  //TODO clarify: Delegate or assertion?
-        // test by components
-        let e_c_list = e_g.get_all_components(None, None)
-                                            .into_iter()
-                                            .filter(|c| e_g.get_graphstorage(c).unwrap().source_nodes().count() > 0)
-                                            .collect_vec();
-        let g_c_list = g.get_all_components(None, None)
-                                            .into_iter()
-                                            .filter(|c| g.get_graphstorage(c).unwrap().source_nodes().count() > 0)  // graph might contain empty components after merge
-                                            .collect_vec();
-        assert_eq!(e_c_list.len(), g_c_list.len(), "components expected:\n{:?};\ncomponents are:\n{:?}", &e_c_list, &g_c_list);
+        let e_corpus_nodes: BTreeSet<String> = e_g
+            .get_node_annos()
+            .exact_anno_search(
+                Some(&NODE_TYPE_KEY.ns),
+                &NODE_TYPE_KEY.name,
+                ValueSearch::Some("corpus"),
+            )
+            .into_iter()
+            .map(|r| r.unwrap().node)
+            .map(|id_| {
+                e_g.get_node_annos()
+                    .get_value_for_item(&id_, &NODE_NAME_KEY)
+                    .unwrap()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+        let g_corpus_nodes: BTreeSet<String> = g
+            .get_node_annos()
+            .exact_anno_search(
+                Some(&NODE_TYPE_KEY.ns),
+                &NODE_TYPE_KEY.name,
+                ValueSearch::Some("corpus"),
+            )
+            .into_iter()
+            .map(|r| r.unwrap().node)
+            .map(|id_| {
+                g.get_node_annos()
+                    .get_value_for_item(&id_, &NODE_NAME_KEY)
+                    .unwrap()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+        assert_eq!(e_corpus_nodes, g_corpus_nodes); //TODO clarify: Delegate or assertion?
+                                                    // test by components
+        let e_c_list = e_g
+            .get_all_components(None, None)
+            .into_iter()
+            .filter(|c| e_g.get_graphstorage(c).unwrap().source_nodes().count() > 0)
+            .collect_vec();
+        let g_c_list = g
+            .get_all_components(None, None)
+            .into_iter()
+            .filter(|c| g.get_graphstorage(c).unwrap().source_nodes().count() > 0) // graph might contain empty components after merge
+            .collect_vec();
+        assert_eq!(
+            e_c_list.len(),
+            g_c_list.len(),
+            "components expected:\n{:?};\ncomponents are:\n{:?}",
+            &e_c_list,
+            &g_c_list
+        );
         for c in e_c_list {
             let candidates = g.get_all_components(Some(c.get_type()), Some(c.name.as_str()));
             assert_eq!(candidates.len(), 1);
-            let c_o  = candidates.get(0);
+            let c_o = candidates.get(0);
             assert_eq!(&c, c_o.unwrap());
         }
         // test with queries
@@ -334,13 +468,13 @@ mod tests {
             "upos",
             "node ->dep node",
             "node ->dep[deprel=/.+/] node",
-            "node ->dep[func=/.+/] node"
+            "node ->dep[func=/.+/] node",
         ];
         let corpus_name = "current";
         let tmp_dir_e = tempdir_in(temp_dir())?;
-        let tmp_dir_g = tempdir_in(temp_dir())?;        
+        let tmp_dir_g = tempdir_in(temp_dir())?;
         e_g.save_to(&tmp_dir_e.path().join(corpus_name))?;
-        g.save_to(&tmp_dir_g.path().join(corpus_name))?;        
+        g.save_to(&tmp_dir_g.path().join(corpus_name))?;
         let cs_e = CorpusStorage::with_auto_cache_size(&tmp_dir_e.path(), true)?;
         let cs_g = CorpusStorage::with_auto_cache_size(&tmp_dir_g.path(), true)?;
         for query_s in queries {
@@ -348,11 +482,16 @@ mod tests {
                 corpus_names: &[corpus_name],
                 query: query_s,
                 query_language: QueryLanguage::AQL,
-                timeout: None
+                timeout: None,
             };
             let matches_e = cs_e.find(query.clone(), 0, None, ResultOrder::Normal)?;
             let matches_g = cs_g.find(query, 0, None, ResultOrder::Normal)?;
-            assert_eq!(matches_e.len(), matches_g.len(), "Failed with query: {}", query_s);
+            assert_eq!(
+                matches_e.len(),
+                matches_g.len(),
+                "Failed with query: {}",
+                query_s
+            );
             for (m_e, m_g) in matches_e.into_iter().zip(matches_g.into_iter()) {
                 assert_eq!(m_e, m_g);
             }
@@ -362,66 +501,95 @@ mod tests {
 
     #[test]
     fn test_move_on_disk() {
-        let r = move_test(true); 
+        let r = move_test(true);
         assert_eq!(r.is_ok(), true, "Probing move test result {:?}", r);
     }
 
     #[test]
     fn test_move_in_mem() {
-        let r = move_test(false); 
+        let r = move_test(false);
         assert_eq!(r.is_ok(), true, "Probing move test result {:?}", r);
     }
 
     fn move_test(on_disk: bool) -> Result<()> {
         let mut g = input_graph_for_move(on_disk)?;
         let mut properties = BTreeMap::new();
-        properties.insert("node.annos".to_string(), "norm::pos:=dipl::derived_pos".to_string());
+        properties.insert(
+            "node.annos".to_string(),
+            "norm::pos:=dipl::derived_pos".to_string(),
+        );
         properties.insert("move.node.annos".to_string(), "true".to_string());
         let replace = Replace::default();
         let result = replace.manipulate_corpus(&mut g, &properties, None);
         assert_eq!(result.is_ok(), true, "Probing merge result {:?}", &result);
         let mut e_g = expected_output_for_move(on_disk)?;
         // corpus nodes
-        let e_corpus_nodes: BTreeSet<String> = e_g.get_node_annos()
-                                        .exact_anno_search(Some(&NODE_TYPE_KEY.ns), &NODE_TYPE_KEY.name, ValueSearch::Some("corpus"))
-                                        .into_iter()
-                                        .map(|r| r.unwrap().node)
-                                        .map(|id_| e_g.get_node_annos().get_value_for_item(&id_, &NODE_NAME_KEY).unwrap().unwrap().to_string())
-                                        .collect();
-        let g_corpus_nodes: BTreeSet<String> = g.get_node_annos()
-                                        .exact_anno_search(Some(&NODE_TYPE_KEY.ns), &NODE_TYPE_KEY.name, ValueSearch::Some("corpus"))
-                                        .into_iter()
-                                        .map(|r| r.unwrap().node)
-                                        .map(|id_| g.get_node_annos().get_value_for_item(&id_, &NODE_NAME_KEY).unwrap().unwrap().to_string())
-                                        .collect();
-        assert_eq!(e_corpus_nodes, g_corpus_nodes);  //TODO clarify: Delegate or assertion?
-        // test by components
-        let e_c_list = e_g.get_all_components(None, None)
-                                            .into_iter()
-                                            .filter(|c| e_g.get_graphstorage(c).unwrap().source_nodes().count() > 0)
-                                            .collect_vec();
-        let g_c_list = g.get_all_components(None, None)
-                                            .into_iter()
-                                            .filter(|c| g.get_graphstorage(c).unwrap().source_nodes().count() > 0)  // graph might contain empty components after merge
-                                            .collect_vec();
-        assert_eq!(e_c_list.len(), g_c_list.len(), "components expected:\n{:?};\ncomponents are:\n{:?}", &e_c_list, &g_c_list);
+        let e_corpus_nodes: BTreeSet<String> = e_g
+            .get_node_annos()
+            .exact_anno_search(
+                Some(&NODE_TYPE_KEY.ns),
+                &NODE_TYPE_KEY.name,
+                ValueSearch::Some("corpus"),
+            )
+            .into_iter()
+            .map(|r| r.unwrap().node)
+            .map(|id_| {
+                e_g.get_node_annos()
+                    .get_value_for_item(&id_, &NODE_NAME_KEY)
+                    .unwrap()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+        let g_corpus_nodes: BTreeSet<String> = g
+            .get_node_annos()
+            .exact_anno_search(
+                Some(&NODE_TYPE_KEY.ns),
+                &NODE_TYPE_KEY.name,
+                ValueSearch::Some("corpus"),
+            )
+            .into_iter()
+            .map(|r| r.unwrap().node)
+            .map(|id_| {
+                g.get_node_annos()
+                    .get_value_for_item(&id_, &NODE_NAME_KEY)
+                    .unwrap()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+        assert_eq!(e_corpus_nodes, g_corpus_nodes); //TODO clarify: Delegate or assertion?
+                                                    // test by components
+        let e_c_list = e_g
+            .get_all_components(None, None)
+            .into_iter()
+            .filter(|c| e_g.get_graphstorage(c).unwrap().source_nodes().count() > 0)
+            .collect_vec();
+        let g_c_list = g
+            .get_all_components(None, None)
+            .into_iter()
+            .filter(|c| g.get_graphstorage(c).unwrap().source_nodes().count() > 0) // graph might contain empty components after merge
+            .collect_vec();
+        assert_eq!(
+            e_c_list.len(),
+            g_c_list.len(),
+            "components expected:\n{:?};\ncomponents are:\n{:?}",
+            &e_c_list,
+            &g_c_list
+        );
         for c in e_c_list {
             let candidates = g.get_all_components(Some(c.get_type()), Some(c.name.as_str()));
             assert_eq!(candidates.len(), 1);
-            let c_o  = candidates.get(0);
+            let c_o = candidates.get(0);
             assert_eq!(&c, c_o.unwrap());
         }
         // test with queries
-        let queries = [
-            "tok",
-            "pos",
-            "derived_pos"
-        ];
+        let queries = ["tok", "pos", "derived_pos"];
         let corpus_name = "current";
         let tmp_dir_e = tempdir_in(temp_dir())?;
-        let tmp_dir_g = tempdir_in(temp_dir())?;        
+        let tmp_dir_g = tempdir_in(temp_dir())?;
         e_g.save_to(&tmp_dir_e.path().join(corpus_name))?;
-        g.save_to(&tmp_dir_g.path().join(corpus_name))?;        
+        g.save_to(&tmp_dir_g.path().join(corpus_name))?;
         let cs_e = CorpusStorage::with_auto_cache_size(&tmp_dir_e.path(), true)?;
         let cs_g = CorpusStorage::with_auto_cache_size(&tmp_dir_g.path(), true)?;
         for query_s in queries {
@@ -429,11 +597,16 @@ mod tests {
                 corpus_names: &[corpus_name],
                 query: query_s,
                 query_language: QueryLanguage::AQL,
-                timeout: None
+                timeout: None,
             };
             let matches_e = cs_e.find(query.clone(), 0, None, ResultOrder::Normal)?;
-            let matches_g = cs_g.find(query, 0, None, ResultOrder::Normal)?;    
-            assert_eq!(matches_e.len(), matches_g.len(), "Failed with query: {}", query_s);
+            let matches_g = cs_g.find(query, 0, None, ResultOrder::Normal)?;
+            assert_eq!(
+                matches_e.len(),
+                matches_g.len(),
+                "Failed with query: {}",
+                query_s
+            );
             for (m_e, m_g) in matches_e.into_iter().zip(matches_g.into_iter()) {
                 assert_eq!(m_e, m_g);
             }
@@ -444,13 +617,23 @@ mod tests {
     #[test]
     fn test_export_mem() {
         let export = export_test(false);
-        assert_eq!(export.is_ok(), true, "Export test ends with Err: {:?}", &export);
+        assert_eq!(
+            export.is_ok(),
+            true,
+            "Export test ends with Err: {:?}",
+            &export
+        );
     }
 
     #[test]
     fn test_export_disk() {
         let export = export_test(true);
-        assert_eq!(export.is_ok(), true, "Export test ends with Err: {:?}", &export);
+        assert_eq!(
+            export.is_ok(),
+            true,
+            "Export test ends with Err: {:?}",
+            &export
+        );
     }
 
     fn export_test(on_disk: bool) -> Result<()> {
@@ -459,9 +642,13 @@ mod tests {
         properties.insert("edge.annos".to_string(), "deprel".to_string());
         properties.insert("node.annos".to_string(), "pos".to_string());
         let replace = Replace::default();
-        assert_eq!(replace.manipulate_corpus(&mut g, &properties, None).is_ok(), true);
+        assert_eq!(
+            replace.manipulate_corpus(&mut g, &properties, None).is_ok(),
+            true
+        );
         let tmp_file = tempfile()?;
-        let export = graphannis_core::graph::serialization::graphml::export(&g, None, tmp_file, |_| {});
+        let export =
+            graphannis_core::graph::serialization::graphml::export(&g, None, tmp_file, |_| {});
         assert_eq!(export.is_ok(), true, "Export fails: {:?}", &export);
         Ok(())
     }
@@ -469,111 +656,157 @@ mod tests {
     #[test]
     fn test_export_move_result_mem() {
         let export = export_test_move_result(false);
-        assert_eq!(export.is_ok(), true, "Testing export of move result ends with Err: {:?}", &export);
+        assert_eq!(
+            export.is_ok(),
+            true,
+            "Testing export of move result ends with Err: {:?}",
+            &export
+        );
     }
 
     #[test]
     fn test_export_move_result_disk() {
         let export = export_test_move_result(true);
-        assert_eq!(export.is_ok(), true, "Testing export of move result ends with Err: {:?}", &export);
+        assert_eq!(
+            export.is_ok(),
+            true,
+            "Testing export of move result ends with Err: {:?}",
+            &export
+        );
     }
 
     fn export_test_move_result(on_disk: bool) -> Result<()> {
         let mut g = input_graph_for_move(on_disk)?;
         let mut properties = BTreeMap::new();
-        properties.insert("node.annos".to_string(), "norm::pos:=dipl::derived_pos".to_string());
+        properties.insert(
+            "node.annos".to_string(),
+            "norm::pos:=dipl::derived_pos".to_string(),
+        );
         properties.insert("move.node.annos".to_string(), "true".to_string());
         let replace = Replace::default();
-        assert_eq!(replace.manipulate_corpus(&mut g, &properties, None).is_ok(), true);
+        assert_eq!(
+            replace.manipulate_corpus(&mut g, &properties, None).is_ok(),
+            true
+        );
         let tmp_file = tempfile()?;
-        let export = graphannis_core::graph::serialization::graphml::export(&g, None, tmp_file, |_| {});
+        let export =
+            graphannis_core::graph::serialization::graphml::export(&g, None, tmp_file, |_| {});
         assert_eq!(export.is_ok(), true, "Export fails: {:?}", &export);
         Ok(())
-    }    
+    }
 
     fn input_graph(on_disk: bool, new_names: bool) -> Result<AnnotationGraph> {
         let mut g = AnnotationGraph::new(on_disk)?;
         let mut u = GraphUpdate::default();
-        u.add_event(UpdateEvent::AddNode { node_name: "root".to_string(), node_type: "corpus".to_string() })?;        
-        u.add_event(UpdateEvent::AddNode { node_name: "root/b".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/b".to_string(), 
-                                           target_node: "root".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;
-        u.add_event(UpdateEvent::AddNode { node_name: "root/b/doc".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/b/doc".to_string(), 
-                                           target_node: "root/b".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;
-        let pos_name = if new_names {
-            "upos"
-        } else {
-            "pos"
-        };
-        for (ii, (txt, lemma_label, pos_label)) in [("I", "I", "PRON"),
-                                                  ("am", "be", "VERB"), 
-                                                  ("in", "in", "ADP"), 
-                                                  ("Berlin", "Berlin", "PROPN")].iter().enumerate() {
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/b".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/b".to_string(),
+            target_node: "root".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/b/doc".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/b/doc".to_string(),
+            target_node: "root/b".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
+        let pos_name = if new_names { "upos" } else { "pos" };
+        for (ii, (txt, lemma_label, pos_label)) in [
+            ("I", "I", "PRON"),
+            ("am", "be", "VERB"),
+            ("in", "in", "ADP"),
+            ("Berlin", "Berlin", "PROPN"),
+        ]
+        .iter()
+        .enumerate()
+        {
             let i = ii + 1;
             let name = format!("root/b/doc#t{}", i);
-            u.add_event(UpdateEvent::AddNode { node_name: name.to_string(), node_type: "node".to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: ANNIS_NS.to_string(), 
-                                                    anno_name: "tok".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: "text".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: "lemma".to_string(), 
-                                                    anno_value: lemma_label.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: pos_name.to_string(), 
-                                                    anno_value: pos_label.to_string() })?;
+            u.add_event(UpdateEvent::AddNode {
+                node_name: name.to_string(),
+                node_type: "node".to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: ANNIS_NS.to_string(),
+                anno_name: "tok".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: "text".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: "lemma".to_string(),
+                anno_value: lemma_label.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: pos_name.to_string(),
+                anno_value: pos_label.to_string(),
+            })?;
             if i > 1 {
-                u.add_event(UpdateEvent::AddEdge { source_node: format!("root/b/doc#t{}", i - 1), 
-                                                   target_node: name.to_string(), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Ordering.to_string(), 
-                                                   component_name: "".to_string() })?;
-                u.add_event(UpdateEvent::AddEdge { source_node: format!("root/b/doc#t{}", i - 1), 
-                                                   target_node: name.to_string(), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Ordering.to_string(), 
-                                                   component_name: "text".to_string() })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: format!("root/b/doc#t{}", i - 1),
+                    target_node: name.to_string(),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Ordering.to_string(),
+                    component_name: "".to_string(),
+                })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: format!("root/b/doc#t{}", i - 1),
+                    target_node: name.to_string(),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Ordering.to_string(),
+                    component_name: "text".to_string(),
+                })?;
             }
         }
         let dep_layer_name = "syntax";
         let dep_comp_name = "dep";
-        let deprel_name = if new_names {
-            "func"
-        } else {
-            "deprel"
-        };
-        for (source, target, label) in [(2, 1, "subj"),
-                                      (2, 3, "comp:pred"),
-                                      (3, 4, "comp:obj")].iter() {
+        let deprel_name = if new_names { "func" } else { "deprel" };
+        for (source, target, label) in
+            [(2, 1, "subj"), (2, 3, "comp:pred"), (3, 4, "comp:obj")].iter()
+        {
             let source_name = format!("root/b/doc#t{}", source);
             let target_name = format!("root/b/doc#t{}", target);
-            u.add_event(UpdateEvent::AddEdge { source_node: source_name.to_string(), 
-                                               target_node: target_name.to_string(), 
-                                               layer: dep_layer_name.to_string(), 
-                                               component_type: AnnotationComponentType::Pointing.to_string(), 
-                                               component_name: dep_comp_name.to_string() })?;
-            u.add_event(UpdateEvent::AddEdgeLabel { source_node: source_name, 
-                                                    target_node: target_name, 
-                                                    layer: dep_layer_name.to_string(), 
-                                                    component_type: AnnotationComponentType::Pointing.to_string(), 
-                                                    component_name: dep_comp_name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: deprel_name.to_string(), 
-                                                    anno_value: label.to_string() })?;
-        }        
+            u.add_event(UpdateEvent::AddEdge {
+                source_node: source_name.to_string(),
+                target_node: target_name.to_string(),
+                layer: dep_layer_name.to_string(),
+                component_type: AnnotationComponentType::Pointing.to_string(),
+                component_name: dep_comp_name.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddEdgeLabel {
+                source_node: source_name,
+                target_node: target_name,
+                layer: dep_layer_name.to_string(),
+                component_type: AnnotationComponentType::Pointing.to_string(),
+                component_name: dep_comp_name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: deprel_name.to_string(),
+                anno_value: label.to_string(),
+            })?;
+        }
         g.apply_update(&mut u, |_msg| {})?;
         Ok(g)
     }
@@ -581,49 +814,76 @@ mod tests {
     fn expected_output_graph(on_disk: bool) -> Result<AnnotationGraph> {
         let mut g = AnnotationGraph::new(on_disk)?;
         let mut u = GraphUpdate::default();
-        u.add_event(UpdateEvent::AddNode { node_name: "root".to_string(), node_type: "corpus".to_string() })?;        
-        u.add_event(UpdateEvent::AddNode { node_name: "root/b".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/b".to_string(), 
-                                           target_node: "root".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;
-        u.add_event(UpdateEvent::AddNode { node_name: "root/b/doc".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/b/doc".to_string(), 
-                                           target_node: "root/b".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;
-        for (ii, (txt, lemma_label)) in [("I", "I"),
-                                                  ("am", "be"), 
-                                                  ("in", "in"), 
-                                                  ("Berlin", "Berlin")].iter().enumerate() {
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/b".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/b".to_string(),
+            target_node: "root".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/b/doc".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/b/doc".to_string(),
+            target_node: "root/b".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
+        for (ii, (txt, lemma_label)) in
+            [("I", "I"), ("am", "be"), ("in", "in"), ("Berlin", "Berlin")]
+                .iter()
+                .enumerate()
+        {
             let i = ii + 1;
             let name = format!("root/b/doc#t{}", i);
-            u.add_event(UpdateEvent::AddNode { node_name: name.to_string(), node_type: "node".to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: ANNIS_NS.to_string(), 
-                                                    anno_name: "tok".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: "text".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: "lemma".to_string(), 
-                                                    anno_value: lemma_label.to_string() })?;
+            u.add_event(UpdateEvent::AddNode {
+                node_name: name.to_string(),
+                node_type: "node".to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: ANNIS_NS.to_string(),
+                anno_name: "tok".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: "text".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: "lemma".to_string(),
+                anno_value: lemma_label.to_string(),
+            })?;
             if i > 1 {
-                u.add_event(UpdateEvent::AddEdge { source_node: format!("root/b/doc#t{}", i - 1), 
-                                                   target_node: name.to_string(), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Ordering.to_string(), 
-                                                   component_name: "".to_string() })?;
-                u.add_event(UpdateEvent::AddEdge { source_node: format!("root/b/doc#t{}", i - 1), 
-                                                   target_node: name.to_string(), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Ordering.to_string(), 
-                                                   component_name: "text".to_string() })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: format!("root/b/doc#t{}", i - 1),
+                    target_node: name.to_string(),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Ordering.to_string(),
+                    component_name: "".to_string(),
+                })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: format!("root/b/doc#t{}", i - 1),
+                    target_node: name.to_string(),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Ordering.to_string(),
+                    component_name: "text".to_string(),
+                })?;
             }
         }
         let dep_layer_name = "syntax";
@@ -631,11 +891,13 @@ mod tests {
         for (source, target) in [(2, 1), (2, 3), (3, 4)].iter() {
             let source_name = format!("root/b/doc#t{}", source);
             let target_name = format!("root/b/doc#t{}", target);
-            u.add_event(UpdateEvent::AddEdge { source_node: source_name.to_string(), 
-                                               target_node: target_name.to_string(), 
-                                               layer: dep_layer_name.to_string(), 
-                                               component_type: AnnotationComponentType::Pointing.to_string(), 
-                                               component_name: dep_comp_name.to_string() })?;
+            u.add_event(UpdateEvent::AddEdge {
+                source_node: source_name.to_string(),
+                target_node: target_name.to_string(),
+                layer: dep_layer_name.to_string(),
+                component_type: AnnotationComponentType::Pointing.to_string(),
+                component_name: dep_comp_name.to_string(),
+            })?;
         }
         g.apply_update(&mut u, |_msg| {})?;
         Ok(g)
@@ -644,111 +906,167 @@ mod tests {
     fn input_graph_for_move(on_disk: bool) -> Result<AnnotationGraph> {
         let mut g = AnnotationGraph::new(on_disk)?;
         let mut u = GraphUpdate::default();
-        u.add_event(UpdateEvent::AddNode { node_name: "root".to_string(), node_type: "corpus".to_string() })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
         // import 1
-        u.add_event(UpdateEvent::AddNode { node_name: "root/a".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/a".to_string(), 
-                                           target_node: "root".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;
-        u.add_event(UpdateEvent::AddNode { node_name: "root/a/doc".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/a/doc".to_string(), 
-                                           target_node: "root/a".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;
-        for i in 0 .. 5 {
-            u.add_event(UpdateEvent::AddNode { node_name: format!("root/a/doc#t{}", i), node_type: "node".to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: format!("root/a/doc#t{}", i), 
-                                                    anno_ns: ANNIS_NS.to_string(), 
-                                                    anno_name: "tok".to_string(), 
-                                                    anno_value: " ".to_string() })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/a".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/a".to_string(),
+            target_node: "root".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/a/doc".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/a/doc".to_string(),
+            target_node: "root/a".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
+        for i in 0..5 {
+            u.add_event(UpdateEvent::AddNode {
+                node_name: format!("root/a/doc#t{}", i),
+                node_type: "node".to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: format!("root/a/doc#t{}", i),
+                anno_ns: ANNIS_NS.to_string(),
+                anno_name: "tok".to_string(),
+                anno_value: " ".to_string(),
+            })?;
             if i > 1 {
-                u.add_event(UpdateEvent::AddEdge { source_node: format!("root/a/doc#t{}", i - 1), 
-                                                   target_node: format!("root/a/doc#t{}", i), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Ordering.to_string(), 
-                                                   component_name: "".to_string() })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: format!("root/a/doc#t{}", i - 1),
+                    target_node: format!("root/a/doc#t{}", i),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Ordering.to_string(),
+                    component_name: "".to_string(),
+                })?;
             }
         }
         // fake-tok 1
         let sentence_span_name = "root/a/doc#s0";
-        u.add_event(UpdateEvent::AddNode { node_name: sentence_span_name.to_string(), node_type: "node".to_string() })?;
-        u.add_event(UpdateEvent::AddNodeLabel { node_name: sentence_span_name.to_string(), 
-                                                anno_ns: "dipl".to_string(),
-                                                anno_name: "sentence".to_string(), 
-                                                anno_value: "1".to_string() })?;
-        for (ii, (txt, start, end)) in [("I'm", 0, 2), 
-                                                  ("in", 2, 3), 
-                                                  ("New", 3, 4), 
-                                                  ("York", 4, 5)].iter().enumerate() {
+        u.add_event(UpdateEvent::AddNode {
+            node_name: sentence_span_name.to_string(),
+            node_type: "node".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddNodeLabel {
+            node_name: sentence_span_name.to_string(),
+            anno_ns: "dipl".to_string(),
+            anno_name: "sentence".to_string(),
+            anno_value: "1".to_string(),
+        })?;
+        for (ii, (txt, start, end)) in [("I'm", 0, 2), ("in", 2, 3), ("New", 3, 4), ("York", 4, 5)]
+            .iter()
+            .enumerate()
+        {
             let i = ii + 1;
             let name = format!("root/a/doc#s{}", i);
-            u.add_event(UpdateEvent::AddNode { node_name: name.to_string(), node_type: "node".to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: ANNIS_NS.to_string(), 
-                                                    anno_name: "tok".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: "dipl".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddEdge { source_node: sentence_span_name.to_string(),
-                                               target_node: name.to_string(),
-                                               layer: ANNIS_NS.to_string(), 
-                                               component_type: AnnotationComponentType::Coverage.to_string(), 
-                                               component_name: "".to_string() })?;
-            for j in *start .. *end {
-                u.add_event(UpdateEvent::AddEdge { source_node: name.to_string(), 
-                                                   target_node: format!("root/a/doc#t{}", j), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Coverage.to_string(), 
-                                                   component_name: "".to_string() })?;
+            u.add_event(UpdateEvent::AddNode {
+                node_name: name.to_string(),
+                node_type: "node".to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: ANNIS_NS.to_string(),
+                anno_name: "tok".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: "dipl".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddEdge {
+                source_node: sentence_span_name.to_string(),
+                target_node: name.to_string(),
+                layer: ANNIS_NS.to_string(),
+                component_type: AnnotationComponentType::Coverage.to_string(),
+                component_name: "".to_string(),
+            })?;
+            for j in *start..*end {
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: name.to_string(),
+                    target_node: format!("root/a/doc#t{}", j),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Coverage.to_string(),
+                    component_name: "".to_string(),
+                })?;
             }
             if i > 1 {
-                u.add_event(UpdateEvent::AddEdge { source_node: format!("root/a/doc#s{}", i - 1), 
-                                                   target_node: name.to_string(), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Ordering.to_string(), 
-                                                   component_name: "dipl".to_string() })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: format!("root/a/doc#s{}", i - 1),
+                    target_node: name.to_string(),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Ordering.to_string(),
+                    component_name: "dipl".to_string(),
+                })?;
             }
         }
         // fake-tok 2
-        for (ii, (txt, start, end, pos_label)) in [("I", 0, 1, "PRON"), 
-                                                  ("am", 1, 2, "VERB"), 
-                                                  ("in", 2, 3, "ADP"), 
-                                                  ("New York", 3, 5, "PROPN")].iter().enumerate() {
+        for (ii, (txt, start, end, pos_label)) in [
+            ("I", 0, 1, "PRON"),
+            ("am", 1, 2, "VERB"),
+            ("in", 2, 3, "ADP"),
+            ("New York", 3, 5, "PROPN"),
+        ]
+        .iter()
+        .enumerate()
+        {
             let i = ii + 5;
             let name = format!("root/a/doc#s{}", i);
-            u.add_event(UpdateEvent::AddNode { node_name: name.to_string(), node_type: "node".to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: ANNIS_NS.to_string(), 
-                                                    anno_name: "tok".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: "norm".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "norm".to_string(), 
-                                                    anno_name: "pos".to_string(), 
-                                                    anno_value: pos_label.to_string() })?;
-            for j in *start .. *end {
-                u.add_event(UpdateEvent::AddEdge { source_node: name.to_string(), 
-                                                   target_node: format!("root/a/doc#t{}", j), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Coverage.to_string(), 
-                                                   component_name: "".to_string() })?;
+            u.add_event(UpdateEvent::AddNode {
+                node_name: name.to_string(),
+                node_type: "node".to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: ANNIS_NS.to_string(),
+                anno_name: "tok".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: "norm".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "norm".to_string(),
+                anno_name: "pos".to_string(),
+                anno_value: pos_label.to_string(),
+            })?;
+            for j in *start..*end {
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: name.to_string(),
+                    target_node: format!("root/a/doc#t{}", j),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Coverage.to_string(),
+                    component_name: "".to_string(),
+                })?;
             }
             if ii > 0 {
-                u.add_event(UpdateEvent::AddEdge { source_node: format!("root/a/doc#s{}", i - 1), 
-                                                   target_node: name.to_string(), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Ordering.to_string(), 
-                                                   component_name: "norm".to_string() })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: format!("root/a/doc#s{}", i - 1),
+                    target_node: name.to_string(),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Ordering.to_string(),
+                    component_name: "norm".to_string(),
+                })?;
             }
-        }        
+        }
         g.apply_update(&mut u, |_msg| {})?;
         Ok(g)
     }
@@ -756,131 +1074,195 @@ mod tests {
     fn expected_output_for_move(on_disk: bool) -> Result<AnnotationGraph> {
         let mut g = AnnotationGraph::new(on_disk)?;
         let mut u = GraphUpdate::default();
-        u.add_event(UpdateEvent::AddNode { node_name: "root".to_string(), node_type: "corpus".to_string() })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
         // import 1
-        u.add_event(UpdateEvent::AddNode { node_name: "root/a".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/a".to_string(), 
-                                           target_node: "root".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;
-        u.add_event(UpdateEvent::AddNode { node_name: "root/a/doc".to_string(), node_type: "corpus".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: "root/a/doc".to_string(), 
-                                           target_node: "root/a".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::PartOf.to_string(), 
-                                           component_name: "".to_string() })?;
-        for i in 0 .. 5 {
-            u.add_event(UpdateEvent::AddNode { node_name: format!("root/a/doc#t{}", i), node_type: "node".to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: format!("root/a/doc#t{}", i), 
-                                                    anno_ns: ANNIS_NS.to_string(), 
-                                                    anno_name: "tok".to_string(), 
-                                                    anno_value: " ".to_string() })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/a".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/a".to_string(),
+            target_node: "root".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/a/doc".to_string(),
+            node_type: "corpus".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: "root/a/doc".to_string(),
+            target_node: "root/a".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::PartOf.to_string(),
+            component_name: "".to_string(),
+        })?;
+        for i in 0..5 {
+            u.add_event(UpdateEvent::AddNode {
+                node_name: format!("root/a/doc#t{}", i),
+                node_type: "node".to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: format!("root/a/doc#t{}", i),
+                anno_ns: ANNIS_NS.to_string(),
+                anno_name: "tok".to_string(),
+                anno_value: " ".to_string(),
+            })?;
             if i > 1 {
-                u.add_event(UpdateEvent::AddEdge { source_node: format!("root/a/doc#t{}", i - 1), 
-                                                   target_node: format!("root/a/doc#t{}", i), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Ordering.to_string(), 
-                                                   component_name: "".to_string() })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: format!("root/a/doc#t{}", i - 1),
+                    target_node: format!("root/a/doc#t{}", i),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Ordering.to_string(),
+                    component_name: "".to_string(),
+                })?;
             }
         }
         // fake-tok 1
         let sentence_span_name = "root/a/doc#s0";
-        u.add_event(UpdateEvent::AddNode { node_name: sentence_span_name.to_string(), node_type: "node".to_string() })?;
-        u.add_event(UpdateEvent::AddNodeLabel { node_name: sentence_span_name.to_string(), 
-                                                anno_ns: "dipl".to_string(),
-                                                anno_name: "sentence".to_string(), 
-                                                anno_value: "1".to_string() })?;
-        for (ii, (txt, start, end, pos_label )) in [("I'm", 0, 2, Some("VERB")), 
-                                                  ("in", 2, 3, Some("ADP")), 
-                                                  ("New", 3, 4, None), 
-                                                  ("York", 4, 5, None)].iter().enumerate() {
+        u.add_event(UpdateEvent::AddNode {
+            node_name: sentence_span_name.to_string(),
+            node_type: "node".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddNodeLabel {
+            node_name: sentence_span_name.to_string(),
+            anno_ns: "dipl".to_string(),
+            anno_name: "sentence".to_string(),
+            anno_value: "1".to_string(),
+        })?;
+        for (ii, (txt, start, end, pos_label)) in [
+            ("I'm", 0, 2, Some("VERB")),
+            ("in", 2, 3, Some("ADP")),
+            ("New", 3, 4, None),
+            ("York", 4, 5, None),
+        ]
+        .iter()
+        .enumerate()
+        {
             let i = ii + 1;
             let name = format!("root/a/doc#s{}", i);
-            u.add_event(UpdateEvent::AddNode { node_name: name.to_string(), node_type: "node".to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: ANNIS_NS.to_string(), 
-                                                    anno_name: "tok".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: "dipl".to_string(), 
-                                                    anno_value: txt.to_string() })?;
+            u.add_event(UpdateEvent::AddNode {
+                node_name: name.to_string(),
+                node_type: "node".to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: ANNIS_NS.to_string(),
+                anno_name: "tok".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: "dipl".to_string(),
+                anno_value: txt.to_string(),
+            })?;
             if let Some(v) = pos_label {
-                u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                        anno_ns: "dipl".to_string(), 
-                                                        anno_name: "derived_pos".to_string(), 
-                                                        anno_value: v.to_string() })?;
+                u.add_event(UpdateEvent::AddNodeLabel {
+                    node_name: name.to_string(),
+                    anno_ns: "dipl".to_string(),
+                    anno_name: "derived_pos".to_string(),
+                    anno_value: v.to_string(),
+                })?;
             }
-            u.add_event(UpdateEvent::AddEdge { source_node: sentence_span_name.to_string(),
-                                               target_node: name.to_string(),
-                                               layer: ANNIS_NS.to_string(), 
-                                               component_type: AnnotationComponentType::Coverage.to_string(), 
-                                               component_name: "".to_string() })?;
-            for j in *start .. *end {
-                u.add_event(UpdateEvent::AddEdge { source_node: name.to_string(), 
-                                                   target_node: format!("root/a/doc#t{}", j), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Coverage.to_string(), 
-                                                   component_name: "".to_string() })?;
+            u.add_event(UpdateEvent::AddEdge {
+                source_node: sentence_span_name.to_string(),
+                target_node: name.to_string(),
+                layer: ANNIS_NS.to_string(),
+                component_type: AnnotationComponentType::Coverage.to_string(),
+                component_name: "".to_string(),
+            })?;
+            for j in *start..*end {
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: name.to_string(),
+                    target_node: format!("root/a/doc#t{}", j),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Coverage.to_string(),
+                    component_name: "".to_string(),
+                })?;
             }
             if i > 1 {
-                u.add_event(UpdateEvent::AddEdge { source_node: format!("root/a/doc#s{}", i - 1), 
-                                                   target_node: name.to_string(), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Ordering.to_string(), 
-                                                   component_name: "dipl".to_string() })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: format!("root/a/doc#s{}", i - 1),
+                    target_node: name.to_string(),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Ordering.to_string(),
+                    component_name: "dipl".to_string(),
+                })?;
             }
         }
         let span_name = "root/a/doc#sSpan1";
-        u.add_event(UpdateEvent::AddNode { node_name: span_name.to_string(), node_type: "node".to_string() })?;
-        u.add_event(UpdateEvent::AddNodeLabel { node_name: span_name.to_string(), 
-                                                anno_ns: "dipl".to_string(), 
-                                                anno_name: "derived_pos".to_string(), 
-                                                anno_value: "PROPN".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: span_name.to_string(), 
-                                           target_node: "root/a/doc#s3".to_string(), 
-                                           layer: ANNIS_NS.to_string(), 
-                                           component_type: AnnotationComponentType::Coverage.to_string(), 
-                                           component_name: "".to_string() })?;
-        u.add_event(UpdateEvent::AddEdge { source_node: span_name.to_string(), 
-                                            target_node: "root/a/doc#s4".to_string(), 
-                                            layer: ANNIS_NS.to_string(), 
-                                            component_type: AnnotationComponentType::Coverage.to_string(), 
-                                            component_name: "".to_string() })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: span_name.to_string(),
+            node_type: "node".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddNodeLabel {
+            node_name: span_name.to_string(),
+            anno_ns: "dipl".to_string(),
+            anno_name: "derived_pos".to_string(),
+            anno_value: "PROPN".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: span_name.to_string(),
+            target_node: "root/a/doc#s3".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::Coverage.to_string(),
+            component_name: "".to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddEdge {
+            source_node: span_name.to_string(),
+            target_node: "root/a/doc#s4".to_string(),
+            layer: ANNIS_NS.to_string(),
+            component_type: AnnotationComponentType::Coverage.to_string(),
+            component_name: "".to_string(),
+        })?;
         // fake-tok 2
-        for (ii, (txt, start, end)) in [("I", 0, 1), 
-                                                  ("am", 1, 2), 
-                                                  ("in", 2, 3), 
-                                                  ("New York", 3, 5)].iter().enumerate() {
+        for (ii, (txt, start, end)) in [("I", 0, 1), ("am", 1, 2), ("in", 2, 3), ("New York", 3, 5)]
+            .iter()
+            .enumerate()
+        {
             let i = ii + 5;
             let name = format!("root/a/doc#s{}", i);
-            u.add_event(UpdateEvent::AddNode { node_name: name.to_string(), node_type: "node".to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: ANNIS_NS.to_string(), 
-                                                    anno_name: "tok".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: name.to_string(), 
-                                                    anno_ns: "".to_string(), 
-                                                    anno_name: "norm".to_string(), 
-                                                    anno_value: txt.to_string() })?;
-            for j in *start .. *end {
-                u.add_event(UpdateEvent::AddEdge { source_node: name.to_string(), 
-                                                   target_node: format!("root/a/doc#t{}", j), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Coverage.to_string(), 
-                                                   component_name: "".to_string() })?;
+            u.add_event(UpdateEvent::AddNode {
+                node_name: name.to_string(),
+                node_type: "node".to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: ANNIS_NS.to_string(),
+                anno_name: "tok".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: name.to_string(),
+                anno_ns: "".to_string(),
+                anno_name: "norm".to_string(),
+                anno_value: txt.to_string(),
+            })?;
+            for j in *start..*end {
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: name.to_string(),
+                    target_node: format!("root/a/doc#t{}", j),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Coverage.to_string(),
+                    component_name: "".to_string(),
+                })?;
             }
             if ii > 0 {
-                u.add_event(UpdateEvent::AddEdge { source_node: format!("root/a/doc#s{}", i - 1), 
-                                                   target_node: name.to_string(), 
-                                                   layer: ANNIS_NS.to_string(), 
-                                                   component_type: AnnotationComponentType::Ordering.to_string(), 
-                                                   component_name: "norm".to_string() })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: format!("root/a/doc#s{}", i - 1),
+                    target_node: name.to_string(),
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Ordering.to_string(),
+                    component_name: "norm".to_string(),
+                })?;
             }
-        }        
+        }
         g.apply_update(&mut u, |_msg| {})?;
         Ok(g)
     }
-
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -51,7 +51,7 @@ impl Importer for PythonImporter {
         _tx: Option<crate::workflow::StatusSender>,
     ) -> Result<graphannis::update::GraphUpdate, Box<dyn std::error::Error>> {
         let python_interpreter = pyembed::MainPythonInterpreter::new(default_python_config())?;
-        
+
         let u: PyResult<_> = python_interpreter.with_gil(|py| {
             // graphannis modul
             wrap_pymodule!(graphannis)(py);
@@ -162,5 +162,4 @@ mod tests {
         g.apply_update(&mut u, |_| {}).unwrap();
         assert_eq!(1, 1)
     }
-    
 }


### PR DESCRIPTION
We have a check for this in the static code analysis, but it's even easier if each PR is automatically fixed.