### PR TITLE
Update the rust cache GitHub action.

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -23,7 +23,7 @@ jobs:
             toolchain: stable
             profile: minimal
             components: llvm-tools-preview
-        - uses: Swatinem/rust-cache@v1.3.0
+        - uses: Swatinem/rust-cache@v2.2.0
         - uses: SierraSoftworks/setup-grcov@v1
           with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -56,7 +56,7 @@ jobs:
           toolchain: stable
           profile: minimal
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v1.3.0
+      - uses: Swatinem/rust-cache@v2.2.0
       - uses: SierraSoftworks/setup-grcov@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There are several depricated functions used by the older version, which should hopefully be fixed in the new one.