### PR TITLE
Fix/ptb import

### DIFF
--- a/merge_test.ato
+++ b/merge_test.ato
@@ -11,14 +11,10 @@
   <importer name="PTBImporter" path="./test/import/">
     <customization>
       <property key="text_name">ptb</property>
-      <property key="anno_ns">norm</property>
+      <property key="anno_ns">topo</property>
+      <property key="edge_layer">const</property>
     </customization>
   </importer>
-  <manipulator name="replace">
-	  <customization>
-		  <property key="node.annos">norm::Number[psor],norm::Gender[psor]</property>
-	  </customization>
-  </manipulator>
   <manipulator name="merge">
     <customization>
       <property key="check.names">norm,conll,ptb</property>
@@ -27,6 +23,11 @@
       <property key="skip.components">,</property>
       <property key="silent">true</property>
     </customization>
+  </manipulator>
+  <manipulator name="replace">
+	  <customization>
+		  <property key="node.annos">norm::Number[psor],norm::Gender[psor]</property>
+	  </customization>
   </manipulator>
   <exporter name="GraphMLExporter" path="./">
 	  <property key="guess.vis">true</property>

--- a/py/PTBImporter.py
+++ b/py/PTBImporter.py
@@ -35,12 +35,12 @@ def map_document(u, path, doc_path, cat_name=_DEFAULT_CAT_NAME, text_name='', an
                 cat, text = stack.pop()
                 token_id = map_token(u, doc_path, len(tokens) + 1, text_name, text)
                 tokens.append(token_id)
-                struct_id = map_hierarchical_annotation(u, doc_path, s_count, '' if anno_ns is None else anno_ns, cat_name, cat, token_id)
+                struct_id = map_hierarchical_annotation(u, doc_path, s_count, '' if anno_ns is None else anno_ns, cat_name, cat, '' if anno_ns is None else anno_ns, token_id)
                 children.append(struct_id)
             elif stack and stack[-1]:
                 s_count += 1
                 (cat,) = stack.pop()
-                struct_id = map_hierarchical_annotation(u, doc_path, s_count, '' if anno_ns is None else anno_ns, cat_name, cat, *children)
+                struct_id = map_hierarchical_annotation(u, doc_path, s_count, '' if anno_ns is None else anno_ns, cat_name, cat, '' if anno_ns is None else anno_ns, *children)
                 children = [struct_id]
         elif c == ' ':
             if val:
@@ -55,7 +55,7 @@ def map_document(u, path, doc_path, cat_name=_DEFAULT_CAT_NAME, text_name='', an
 
 def start_import(path, **properties):
     """
-    Import all conll documents in the given directory.
+    Import all ptb documents in the given directory.
     >>> type(start_import('test/import/ptb')).__name__
     'GraphUpdate'
     """

--- a/py/PTBImporter.py
+++ b/py/PTBImporter.py
@@ -5,15 +5,14 @@ import logging
 import re
 
 
-_PROP_TEXT_NAME = 'text_name'
-_PROP_ANNO_NS = 'anno_ns'
-_PROP_EDGE_NS = 'edge_layer'
+_PROP_LAYER_NAME = 'layer_name'
+_NODE_ANNO_NAME = 'node_anno_name'
 _FILE_ENDINGS = ('.ptb',)
 _FIXED_SEQUENCES = {
     '-LRB-': '(',
     '-RRB-': ')'
 }
-_DEFAULT_CAT_NAME = 'cat'
+_DEFAULT_NODE_ANNO_NAME = 'cat'
 
 
 _logger = logging.getLogger(__name__)
@@ -29,7 +28,7 @@ def clean_text(text):
     return text
 
 
-def map_document(u, path, doc_path, cat_name=_DEFAULT_CAT_NAME, text_name='', anno_ns=None, edge_layer=None):
+def map_document(u, path, doc_path, cat_name=_DEFAULT_NODE_ANNO_NAME, layer_name=None, node_anno_name=_DEFAULT_NODE_ANNO_NAME):
     with open(path) as f:
         data = f.read()
     stack = []
@@ -53,16 +52,16 @@ def map_document(u, path, doc_path, cat_name=_DEFAULT_CAT_NAME, text_name='', an
                 val = ''
                 cat, text = stack.pop()
                 index_stack.pop()
-                token_id = map_token(u, doc_path, len(tokens) + 1, text_name, clean_text(text))
+                token_id = map_token(u, doc_path, len(tokens) + 1, layer_name, clean_text(text))
                 tokens.append(token_id)
-                struct_id = map_hierarchical_annotation(u, doc_path, s_count, '' if anno_ns is None else anno_ns, cat_name, cat, '' if edge_layer is None else edge_layer, token_id)                
+                struct_id = map_hierarchical_annotation(u, doc_path, s_count, '' if layer_name is None else layer_name, node_anno_name, cat, '' if layer_name is None else layer_name, token_id)                
                 covered_tokens[struct_id].append(token_id)
                 children.append(struct_id)
             elif stack and stack[-1]:
                 s_count += 1
                 (cat,) = stack.pop()                
                 child_index = index_stack.pop()
-                struct_id = map_hierarchical_annotation(u, doc_path, s_count, '' if anno_ns is None else anno_ns, cat_name, cat, '' if edge_layer is None else edge_layer, *children[child_index:])
+                struct_id = map_hierarchical_annotation(u, doc_path, s_count, '' if layer_name is None else layer_name, node_anno_name, cat, '' if layer_name is None else layer_name, *children[child_index:])
                 for child in children[child_index:]:
                     covered_tokens[struct_id].extend(covered_tokens[child])
                 children = children[:child_index]
@@ -76,8 +75,8 @@ def map_document(u, path, doc_path, cat_name=_DEFAULT_CAT_NAME, text_name='', an
     for dominating_node, dominated_tokens in covered_tokens.items():
         coverage(u, [dominating_node], dominated_tokens)
     add_order_relations(u, tokens)
-    if text_name:
-        add_order_relations(u, tokens, text_name)
+    if layer_name:
+        add_order_relations(u, tokens, layer_name)
 
 
 def start_import(path, **properties):
@@ -87,7 +86,6 @@ def start_import(path, **properties):
     'GraphUpdate'
     """
     u = GraphUpdate()
-    safe_props = defaultdict(type(None), properties)
     for path, internal_path in path_structure(u, path, _FILE_ENDINGS):
-        map_document(u, path, internal_path, text_name=safe_props[_PROP_TEXT_NAME], anno_ns=safe_props[_PROP_ANNO_NS], edge_layer=safe_props[_PROP_EDGE_NS])
+        map_document(u, path, internal_path, **properties)
     return u

--- a/py/graphupdate_util.py
+++ b/py/graphupdate_util.py
@@ -107,11 +107,12 @@ def map_annotation(u, doc_path, id_, ns, name, value, *targets):
     return span_id
 
 
-def map_hierarchical_annotation(u, doc_path, id_, ns, name, value, *targets, edge_layer=''):
+def map_hierarchical_annotation(u, doc_path, id_, ns, name, value, edge_layer, *targets):
     struct_id = f'{doc_path}#sStruct{id_}'
     u.add_node(struct_id)
     if name:
         u.add_node_label(struct_id, ns, name, value)
+    u.add_node_label(struct_id, ANNIS_NS, ANNIS_NAME_LAYER, ns)
     for target in targets:
         dominance(u, [struct_id], [target], layer=edge_layer)
     return struct_id

--- a/py/graphupdate_util.py
+++ b/py/graphupdate_util.py
@@ -112,9 +112,8 @@ def map_hierarchical_annotation(u, doc_path, id_, ns, name, value, edge_layer, *
     u.add_node(struct_id)
     if name:
         u.add_node_label(struct_id, ns, name, value)
-    u.add_node_label(struct_id, ANNIS_NS, ANNIS_NAME_LAYER, ns)
-    for target in targets:
-        dominance(u, [struct_id], [target], layer=edge_layer)
+    u.add_node_label(struct_id, ANNIS_NS, ANNIS_NAME_LAYER, ns)    
+    dominance(u, [struct_id], targets, layer=edge_layer)
     return struct_id
 
 

--- a/src/exporter/graphml.rs
+++ b/src/exporter/graphml.rs
@@ -8,7 +8,7 @@ use crate::{
     error::AnnattoError, exporter::Exporter, progress::ProgressReporter, workflow::StatusSender,
     Module,
 };
-use graphannis::model::{AnnotationComponent, AnnotationComponentType};
+use graphannis::{model::{AnnotationComponent, AnnotationComponentType}, graph::AnnoKey};
 use graphannis::AnnotationGraph;
 use graphannis_core::{
     annostorage::ValueSearch,
@@ -121,15 +121,15 @@ fn tree_vis(graph: &AnnotationGraph) -> Result<Vec<Visualizer>, Box<dyn std::err
             mappings.insert("node_anno_ns".to_string(), ns.to_string());
         }
         mappings.insert("node_key".to_string(), name.to_string());
+        let layer = match node_annos.get_value_for_item(&storage.source_nodes().last().unwrap()?, &AnnoKey { ns: ANNIS_NS.into(), name: "layer".into()})? {
+            None => None,
+            Some(v) => Some(v.to_string())
+        };
         visualizers.push(Visualizer {
             element: "node".to_string(),
-            layer: if c.layer.is_empty() {
-                None
-            } else {
-                Some(c.layer.to_string())
-            },
+            layer: layer,
             vis_type: "tree".to_string(),
-            display_name: format!("dominance ({})", c.layer),
+            display_name: "dominance ({})".to_string(),
             visibility: "hidden".to_string(),
             mappings: Some(mappings),
         });

--- a/src/exporter/graphml.rs
+++ b/src/exporter/graphml.rs
@@ -1,7 +1,7 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fs::{create_dir_all, File},
-    path::Path,
+    path::Path, cmp::Ordering,
 };
 
 use crate::{
@@ -69,10 +69,10 @@ fn tree_vis(graph: &AnnotationGraph) -> Result<Vec<Visualizer>, Box<dyn std::err
     for c in graph.get_all_components(Some(AnnotationComponentType::Dominance), None) {
         let mut mappings = BTreeMap::new();
         let storage = graph.get_graphstorage(&c).unwrap();
-        { // determine terminal name
-            let start_node_result = storage.source_nodes().last();        
-            if let Some(node_result) = start_node_result {
-                let dfs = CycleSafeDFS::new(storage.as_edgecontainer(), node_result?, 1, usize::MAX);
+        let random_struct = storage.source_nodes().last();
+        { // determine terminal name        
+            if let Some(Ok(ref start_node)) = random_struct {
+                let dfs = CycleSafeDFS::new(storage.as_edgecontainer(), *start_node, 1, usize::MAX);
                 let terminal = dfs
                     .into_iter()
                     .find(|nr| {
@@ -96,7 +96,7 @@ fn tree_vis(graph: &AnnotationGraph) -> Result<Vec<Visualizer>, Box<dyn std::err
             }
             mappings.insert("edge_key".to_string(), first_key.name.to_string());
         }
-        mappings.insert("edge_type".to_string(), "edge".to_string());
+        mappings.insert("edge_type".to_string(), c.name.to_string());
         let mut node_names: BTreeMap<String, i32> = BTreeMap::new();
         for node_r in storage.source_nodes() {
             let node = node_r?;
@@ -121,7 +121,7 @@ fn tree_vis(graph: &AnnotationGraph) -> Result<Vec<Visualizer>, Box<dyn std::err
             mappings.insert("node_anno_ns".to_string(), ns.to_string());
         }
         mappings.insert("node_key".to_string(), name.to_string());
-        let layer = match node_annos.get_value_for_item(&storage.source_nodes().last().unwrap()?, &AnnoKey { ns: ANNIS_NS.into(), name: "layer".into()})? {
+        let layer = match node_annos.get_value_for_item(&random_struct.unwrap()?, &AnnoKey { ns: ANNIS_NS.into(), name: "layer".into()})? {
             None => None,
             Some(v) => Some(v.to_string())
         };
@@ -129,7 +129,7 @@ fn tree_vis(graph: &AnnotationGraph) -> Result<Vec<Visualizer>, Box<dyn std::err
             element: "node".to_string(),
             layer: layer,
             vis_type: "tree".to_string(),
-            display_name: "dominance ({})".to_string(),
+            display_name: "dominance".to_string(),
             visibility: "hidden".to_string(),
             mappings: Some(mappings),
         });
@@ -231,38 +231,90 @@ fn media_vis(graph: &AnnotationGraph) -> Result<Vec<Visualizer>, Box<dyn std::er
     Ok(vis)
 }
 
-fn vis_from_graph(graph: &AnnotationGraph) -> Result<String, Box<dyn std::error::Error>> {
-    let mut vis_list = Vec::new();
-    // edge annos
-    vis_list.extend(tree_vis(graph)?);
-    vis_list.extend(arch_vis(graph)?);
-    // node annos
+fn collect_qnames(graph: &AnnotationGraph,
+                node_id: &u64) -> Result<BTreeSet<String>, Box<dyn std::error::Error>> {
+    let mut key_set = BTreeSet::new();
+    for key in graph.get_node_annos().get_all_keys_for_item(node_id, None, None)? {
+        key_set.insert(join_qname(&key.ns, &key.name));
+    }
+    Ok(key_set)
+}
+
+fn node_annos_vis(graph: &AnnotationGraph) -> Result<Visualizer, Box<dyn std::error::Error>> {
     let order_names = get_orderings(graph);
     let orderings = order_names
         .iter()
         .filter(|s| !s.is_empty())
         .map(|s| format!("/{}/", s))
         .join(",");
-    let node_names = graph
-        .get_node_annos()
-        .annotation_keys()?
-        .iter()
-        .filter(|k| !order_names.contains(&k.name.to_string()) && k.ns.as_str() != ANNIS_NS)
-        .map(|k| format!("/{}/", join_qname(&k.ns, &k.name)))
+    let mut node_qnames = BTreeSet::new();
+    let mut visited = BTreeSet::new();
+    // gather all qnames that occur on nodes reachable through coverage edges (other annotations cannot be visualized in grid)
+    for component in graph.get_all_components(Some(AnnotationComponentType::Coverage), None) {
+        let storage = graph.get_graphstorage(&component).unwrap();
+        for source_node_r in storage.source_nodes() {
+            if let Ok(source_node) = source_node_r {
+                if !visited.contains(&source_node) {
+                    visited.insert(source_node);
+                    node_qnames.extend(collect_qnames(graph, &source_node)?);
+                }
+                let dfs = CycleSafeDFS::new(storage.as_edgecontainer(), source_node, 1, usize::MAX);
+                for step_r in dfs {
+                    let step_node = step_r?.node;
+                    if !visited.contains(&step_node) {                    
+                        visited.insert(step_node);
+                        node_qnames.extend(collect_qnames(graph, &step_node)?);
+                    }
+                }
+            }
+        }
+    }
+    let mut sorted_node_qnames = node_qnames.into_iter().collect_vec();
+    sorted_node_qnames.sort();
+    let node_names = sorted_node_qnames
+        .into_iter()
+        .filter(|name| !order_names.contains(&name) && !name.starts_with(format!("{}::", ANNIS_NS).as_str()))
+        .map(|name| format!("/{}/", name))
         .join(",");
     let mut mappings = BTreeMap::new();
     mappings.insert("annos".to_string(), [orderings, node_names].join(","));
     mappings.insert("escape_html".to_string(), "false".to_string());
-    mappings.insert("hide_tok".to_string(), "true".to_string());
+    let more_than_one_ordering = !order_names.is_empty();  // reminder: order_names does not contain the unnamed ordering, therefore !is_empty is the way to go
+    let ordered_nodes_are_identical = {
+        more_than_one_ordering && {
+            let ordering_components = graph.get_all_components(Some(AnnotationComponentType::Ordering), None);
+            let node_sets = ordering_components
+                .iter()
+                .map(|c| graph.get_graphstorage(c).unwrap().source_nodes().into_iter().map(|r| r.unwrap()).collect::<BTreeSet<u64>>())
+                .collect_vec();            
+            let mut all_same = true;
+            for i in 1 .. node_sets.len() {
+                let a = node_sets.get(i - 1).unwrap();
+                let b = node_sets.get(i).unwrap();
+                all_same &= a.cmp(b) == Ordering::Equal;
+            }
+            all_same
+        }
+    };
+    mappings.insert("hide_tok".to_string(), (!ordered_nodes_are_identical).to_string());
     mappings.insert("show_ns".to_string(), "false".to_string());
-    vis_list.push(Visualizer {
+    Ok(Visualizer {
         element: "node".to_string(),
         layer: None,
         vis_type: "grid".to_string(),
         display_name: "annotations".to_string(),
         visibility: "hidden".to_string(),
         mappings: Some(mappings),
-    });
+    })
+}
+
+fn vis_from_graph(graph: &AnnotationGraph) -> Result<String, Box<dyn std::error::Error>> {
+    let mut vis_list = Vec::new();
+    // edge annos
+    vis_list.extend(tree_vis(graph)?);
+    vis_list.extend(arch_vis(graph)?);
+    // node annos
+    vis_list.push(node_annos_vis(graph)?);
     vis_list.extend(media_vis(graph)?);
     let vis = toml::to_string(&Visualization {
         visualizers: vis_list,

--- a/src/manipulator/re.rs
+++ b/src/manipulator/re.rs
@@ -288,15 +288,36 @@ fn replace_namespaces(
     for (old_namespace, new_namespace_opt) in renamings.iter() {
         let new_ns = match new_namespace_opt {
             None => "".to_string(),
-            Some(v) => v.to_string()
+            Some(v) => v.to_string(),
         };
-        for ak in node_annos.annotation_keys()?.into_iter().filter(|k| k.ns.to_string() == *old_namespace) {
-            for m_r in node_annos.exact_anno_search(Some(old_namespace.as_str()), &ak.name.as_str(), ValueSearch::Any) {
+        for ak in node_annos
+            .annotation_keys()?
+            .into_iter()
+            .filter(|k| k.ns.to_string() == *old_namespace)
+        {
+            for m_r in node_annos.exact_anno_search(
+                Some(old_namespace.as_str()),
+                &ak.name.as_str(),
+                ValueSearch::Any,
+            ) {
                 let m = m_r?;
-                let node_name = node_annos.get_value_for_item(&m.node, &NODE_NAME_KEY)?.unwrap();
-                let value = node_annos.get_value_for_item(&m.node, &m.anno_key)?.unwrap();
-                update.add_event(UpdateEvent::DeleteNodeLabel { node_name: node_name.to_string(), anno_ns: m.anno_key.ns.to_string(), anno_name: m.anno_key.name.to_string() })?;
-                update.add_event(UpdateEvent::AddNodeLabel { node_name: node_name.to_string(), anno_ns: new_ns.to_string(), anno_name: m.anno_key.name.to_string(), anno_value: value.to_string() })?;
+                let node_name = node_annos
+                    .get_value_for_item(&m.node, &NODE_NAME_KEY)?
+                    .unwrap();
+                let value = node_annos
+                    .get_value_for_item(&m.node, &m.anno_key)?
+                    .unwrap();
+                update.add_event(UpdateEvent::DeleteNodeLabel {
+                    node_name: node_name.to_string(),
+                    anno_ns: m.anno_key.ns.to_string(),
+                    anno_name: m.anno_key.name.to_string(),
+                })?;
+                update.add_event(UpdateEvent::AddNodeLabel {
+                    node_name: node_name.to_string(),
+                    anno_ns: new_ns.to_string(),
+                    anno_name: m.anno_key.name.to_string(),
+                    anno_value: value.to_string(),
+                })?;
             }
         }
     }
@@ -306,39 +327,60 @@ fn replace_namespaces(
         for (old_namespace, new_namespace_opt) in renamings.iter() {
             let new_ns = match new_namespace_opt {
                 None => "".to_string(),
-                Some(v) => v.to_string()
+                Some(v) => v.to_string(),
             };
-            for ak in storage.get_anno_storage().annotation_keys()?.into_iter().filter(|k| k.ns.to_string() == *old_namespace) {
-                for m_r in storage.get_anno_storage().exact_anno_search(Some(old_namespace.as_str()), &ak.name.as_str(), ValueSearch::Any) {
+            for ak in storage
+                .get_anno_storage()
+                .annotation_keys()?
+                .into_iter()
+                .filter(|k| k.ns.to_string() == *old_namespace)
+            {
+                for m_r in storage.get_anno_storage().exact_anno_search(
+                    Some(old_namespace.as_str()),
+                    &ak.name.as_str(),
+                    ValueSearch::Any,
+                ) {
                     let m = m_r?;
                     let source_node = m.node;
-                    let source_node_name = node_annos.get_value_for_item(&source_node, &NODE_NAME_KEY)?.unwrap();
+                    let source_node_name = node_annos
+                        .get_value_for_item(&source_node, &NODE_NAME_KEY)?
+                        .unwrap();
                     for target_r in storage.get_outgoing_edges(source_node) {
                         let target_node = target_r?;
-                        if let Some(value) = storage.get_anno_storage().get_value_for_item(&Edge { source: source_node, target: target_node }, &m.anno_key)? {
-                            let target_node_name = node_annos.get_value_for_item(&target_node, &NODE_NAME_KEY)?.unwrap();
-                            update.add_event(UpdateEvent::DeleteEdgeLabel { 
-                                source_node: source_node_name.to_string(), 
-                                target_node: target_node_name.to_string(), 
-                                layer: component.layer.to_string(), 
-                                component_type: component.get_type().to_string(), 
+                        if let Some(value) = storage.get_anno_storage().get_value_for_item(
+                            &Edge {
+                                source: source_node,
+                                target: target_node,
+                            },
+                            &m.anno_key,
+                        )? {
+                            let target_node_name = node_annos
+                                .get_value_for_item(&target_node, &NODE_NAME_KEY)?
+                                .unwrap();
+                            update.add_event(UpdateEvent::DeleteEdgeLabel {
+                                source_node: source_node_name.to_string(),
+                                target_node: target_node_name.to_string(),
+                                layer: component.layer.to_string(),
+                                component_type: component.get_type().to_string(),
                                 component_name: component.name.to_string(),
-                                anno_ns: m.anno_key.ns.to_string(), 
-                                anno_name: m.anno_key.name.to_string() })?;
-                            update.add_event(UpdateEvent::AddEdgeLabel { 
-                                source_node: source_node_name.to_string(), 
-                                target_node: target_node_name.to_string(), 
-                                layer: component.layer.to_string(), 
-                                component_type: component.get_type().to_string(), 
-                                component_name: component.name.to_string(), 
-                                anno_ns: new_ns.to_string(), 
-                                anno_name: m.anno_key.name.to_string(), 
-                                anno_value: value.to_string() })?;
+                                anno_ns: m.anno_key.ns.to_string(),
+                                anno_name: m.anno_key.name.to_string(),
+                            })?;
+                            update.add_event(UpdateEvent::AddEdgeLabel {
+                                source_node: source_node_name.to_string(),
+                                target_node: target_node_name.to_string(),
+                                layer: component.layer.to_string(),
+                                component_type: component.get_type().to_string(),
+                                component_name: component.name.to_string(),
+                                anno_ns: new_ns.to_string(),
+                                anno_name: m.anno_key.name.to_string(),
+                                anno_value: value.to_string(),
+                            })?;
                         }
                     }
                 }
             }
-        }        
+        }
     }
     Ok(())
 }
@@ -418,7 +460,7 @@ impl Manipulator for Replace {
                     let old_namespace = k.name.to_string();
                     let new_namespace = match k_opt {
                         None => None,
-                        Some(v) => Some(v.name.to_string())
+                        Some(v) => Some(v.name.to_string()),
                     };
                     (old_namespace, new_namespace)
                 })
@@ -790,7 +832,7 @@ mod tests {
 
     #[test]
     fn namespace_test_in_mem() {
-        let r = namespace_test(false); 
+        let r = namespace_test(false);
         assert_eq!(r.is_ok(), true, "Failed with: {:?}", &r);
     }
 
@@ -804,9 +846,17 @@ mod tests {
         let mut g = namespace_test_graph(on_disk, false)?;
         let replace = Replace::default();
         let mut properties = BTreeMap::new();
-        properties.insert(PROP_ANNO_NAMESPACES.to_string(), "ud:=default_ns,:=default_ns".to_string());
+        properties.insert(
+            PROP_ANNO_NAMESPACES.to_string(),
+            "ud:=default_ns,:=default_ns".to_string(),
+        );
         let op_result = replace.manipulate_corpus(&mut g, &properties, None);
-        assert_eq!(op_result.is_ok(), true, "Replacing namespaces failed: {:?}", &op_result);
+        assert_eq!(
+            op_result.is_ok(),
+            true,
+            "Replacing namespaces failed: {:?}",
+            &op_result
+        );
         let mut e_g = namespace_test_graph(on_disk, true)?;
         // corpus nodes
         let e_corpus_nodes: BTreeSet<String> = e_g
@@ -869,7 +919,17 @@ mod tests {
             assert_eq!(&c, c_o.unwrap());
         }
         // test with queries
-        let queries = ["tok", "pos", "ud:pos", "default_ns:pos", "lemma", "default_ns:lemma", "node ->dep[func=/.*/] node", "node ->dep[ud:func=/.*/] node", "node ->dep[default_ns:func=/.*/] node"];
+        let queries = [
+            "tok",
+            "pos",
+            "ud:pos",
+            "default_ns:pos",
+            "lemma",
+            "default_ns:lemma",
+            "node ->dep[func=/.*/] node",
+            "node ->dep[ud:func=/.*/] node",
+            "node ->dep[default_ns:func=/.*/] node",
+        ];
         let corpus_name = "current";
         let tmp_dir_e = tempdir_in(temp_dir())?;
         let tmp_dir_g = tempdir_in(temp_dir())?;
@@ -1476,27 +1536,63 @@ mod tests {
         let corpus_type = "corpus";
         let node_type = "node";
         let doc_path = "root/subnode/doc";
-        u.add_event(UpdateEvent::AddNode { node_name: "root".to_string(), node_type: corpus_type.to_string() })?;
-        u.add_event(UpdateEvent::AddNode { node_name: "root/subnode".to_string(), node_type: corpus_type.to_string() })?;
-        u.add_event(UpdateEvent::AddNode { node_name: doc_path.to_string(), node_type: corpus_type.to_string() })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root".to_string(),
+            node_type: corpus_type.to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "root/subnode".to_string(),
+            node_type: corpus_type.to_string(),
+        })?;
+        u.add_event(UpdateEvent::AddNode {
+            node_name: doc_path.to_string(),
+            node_type: corpus_type.to_string(),
+        })?;
         let default_ns = "default_ns";
         let pos_ns = if after { default_ns } else { "ud" };
         let pos_name = "pos";
         let lemma_ns = if after { default_ns } else { "" };
         let lemma_name = "lemma";
-        for (i, (text, pos_value, lemma_value)) in [("This", "PRON", "this"), ("is", "VERB", "be"), ("a", "DET", "a"), ("test", "NOUN", "test")].iter().enumerate() {
+        for (i, (text, pos_value, lemma_value)) in [
+            ("This", "PRON", "this"),
+            ("is", "VERB", "be"),
+            ("a", "DET", "a"),
+            ("test", "NOUN", "test"),
+        ]
+        .iter()
+        .enumerate()
+        {
             let tok_name = format!("{}#t{}", doc_path, &(i + 1));
-            u.add_event(UpdateEvent::AddNode { node_name: tok_name.to_string(), node_type: node_type.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: tok_name.to_string(), anno_ns: ANNIS_NS.to_string(), anno_name: "tok".to_string(), anno_value: text.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: tok_name.to_string(), anno_ns: lemma_ns.to_string(), anno_name: lemma_name.to_string(), anno_value: lemma_value.to_string() })?;
-            u.add_event(UpdateEvent::AddNodeLabel { node_name: tok_name.to_string(), anno_ns: pos_ns.to_string(), anno_name: pos_name.to_string(), anno_value: pos_value.to_string() })?;
+            u.add_event(UpdateEvent::AddNode {
+                node_name: tok_name.to_string(),
+                node_type: node_type.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: tok_name.to_string(),
+                anno_ns: ANNIS_NS.to_string(),
+                anno_name: "tok".to_string(),
+                anno_value: text.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: tok_name.to_string(),
+                anno_ns: lemma_ns.to_string(),
+                anno_name: lemma_name.to_string(),
+                anno_value: lemma_value.to_string(),
+            })?;
+            u.add_event(UpdateEvent::AddNodeLabel {
+                node_name: tok_name.to_string(),
+                anno_ns: pos_ns.to_string(),
+                anno_name: pos_name.to_string(),
+                anno_value: pos_value.to_string(),
+            })?;
             if i.gt(&0) {
-                u.add_event(UpdateEvent::AddEdge { 
-                    source_node: format!("{}#t{}", doc_path, &i), 
-                    target_node: tok_name, 
-                    layer: ANNIS_NS.to_string(), 
-                    component_type: AnnotationComponentType::Ordering.to_string(), 
-                    component_name: "".to_string() })?;
+                u.add_event(UpdateEvent::AddEdge {
+                    source_node: format!("{}#t{}", doc_path, &i),
+                    target_node: tok_name,
+                    layer: ANNIS_NS.to_string(),
+                    component_type: AnnotationComponentType::Ordering.to_string(),
+                    component_name: "".to_string(),
+                })?;
             }
         }
         let func_name = "func";
@@ -1504,22 +1600,23 @@ mod tests {
         for (source_i, target_i, func_value) in [(4, 1, "subj"), (4, 2, "cop"), (4, 3, "det")] {
             let source_name = format!("{}#t{}", doc_path, &source_i);
             let target_name = format!("{}#t{}", doc_path, &target_i);
-            u.add_event(UpdateEvent::AddEdge { 
-                source_node: source_name.to_string(), 
-                target_node: target_name.to_string(), 
-                layer: "".to_string(), 
-                component_type: AnnotationComponentType::Pointing.to_string(), 
-                component_name: "dep".to_string() 
+            u.add_event(UpdateEvent::AddEdge {
+                source_node: source_name.to_string(),
+                target_node: target_name.to_string(),
+                layer: "".to_string(),
+                component_type: AnnotationComponentType::Pointing.to_string(),
+                component_name: "dep".to_string(),
             })?;
-            u.add_event(UpdateEvent::AddEdgeLabel { 
-                source_node: source_name.to_string(), 
-                target_node: target_name.to_string(), 
-                layer: "".to_string(), 
-                component_type: AnnotationComponentType::Pointing.to_string(), 
-                component_name: "dep".to_string(), 
-                anno_ns: func_ns.to_string(), 
-                anno_name: func_name.to_string(), 
-                anno_value: func_value.to_string() })?;
+            u.add_event(UpdateEvent::AddEdgeLabel {
+                source_node: source_name.to_string(),
+                target_node: target_name.to_string(),
+                layer: "".to_string(),
+                component_type: AnnotationComponentType::Pointing.to_string(),
+                component_name: "dep".to_string(),
+                anno_ns: func_ns.to_string(),
+                anno_name: func_name.to_string(),
+                anno_value: func_value.to_string(),
+            })?;
         }
         g.apply_update(&mut u, |_| {})?;
         Ok(g)


### PR DESCRIPTION
If property `layer_name` is set for PTBImporter, the exported data works from scratch w/o any further configuration of visualizers. 

The importer now adds coverage edges from structs to indirectly dominated terminal nodes.