### PR TITLE
use util function for obtaining all paths

### DIFF
--- a/src/importer/corpus_annotations.rs
+++ b/src/importer/corpus_annotations.rs
@@ -10,7 +10,7 @@ use graphannis::{
 };
 use graphannis_core::{graph::ANNIS_NS, util::split_qname};
 
-use crate::{workflow::StatusMessage, Module};
+use crate::{util::get_all_files, workflow::StatusMessage, Module};
 
 use super::Importer;
 
@@ -56,11 +56,7 @@ impl Importer for AnnotateCorpus {
         tx: Option<crate::workflow::StatusSender>,
     ) -> Result<graphannis::update::GraphUpdate, Box<dyn std::error::Error>> {
         let mut update = GraphUpdate::default();
-        let path_pattern = input_path.join("**/*.meta");
-        dbg!(&path_pattern);
-        let files = glob::glob(path_pattern.to_str().unwrap())?;
-        for file_path_r in files {
-            let file_path = file_path_r?;
+        for file_path in get_all_files(input_path, vec!["meta"])? {
             let mut corpus_nodes = Vec::new();
             for ancestor in file_path.ancestors() {
                 if ancestor == input_path {

--- a/src/importer/spreadsheet.rs
+++ b/src/importer/spreadsheet.rs
@@ -10,7 +10,11 @@ use graphannis::{
 use graphannis_core::{graph::ANNIS_NS, util::split_qname};
 use itertools::Itertools;
 
-use crate::{error::AnnattoError, util::insert_corpus_nodes_from_path, Module};
+use crate::{
+    error::AnnattoError,
+    util::{get_all_files, insert_corpus_nodes_from_path},
+    Module,
+};
 
 use super::Importer;
 
@@ -241,12 +245,10 @@ impl Importer for ImportSpreadsheet {
                 path: input_path.to_path_buf(),
             }));
         };
-        let dummy_path = input_path.join("**").join("*.xlsx");
-        let path_pattern = dummy_path.to_str().unwrap();
-        for file_path_r in glob::glob(path_pattern)? {
-            let file_path = file_path_r?;
-            import_workbook(&mut update, input_path, file_path.as_path(), &column_map)?;
-        }
+        let all_files = get_all_files(input_path, vec!["xlsx"])?;
+        all_files.into_iter().try_for_each(|pb| {
+            import_workbook(&mut update, input_path, pb.as_path(), &column_map)
+        })?;
         Ok(update)
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,7 +13,7 @@ use std::{
     collections::BTreeMap,
     fs::File,
     io::{BufWriter, Write},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 pub mod graphupdate;
@@ -32,6 +32,21 @@ pub fn write_to_file(updates: &GraphUpdate, path: &std::path::Path) -> Result<()
         file.write_all(b"\n")?;
     }
     Ok(())
+}
+
+pub fn get_all_files(
+    corpus_root_dir: &Path,
+    file_extensions: Vec<&str>,
+) -> std::result::Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    let mut paths = Vec::new();
+    let flex_path = corpus_root_dir.join("**");
+    for ext in file_extensions {
+        let ext_path = flex_path.join(format!("*.{ext}"));
+        for file_opt in glob::glob(&ext_path.to_string_lossy())? {
+            paths.push(file_opt?)
+        }
+    }
+    Ok(paths)
 }
 
 pub fn insert_corpus_nodes_from_path(


### PR DESCRIPTION
removes code duplicates by using util function for iterating all files; this is still inconsistent with other modules using `path_structure`, hence some unification is required