### PR TITLE
Feature/env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - after running `check`, the the test results can be printed as a table (default: off)
 - `check` displays matching nodes for tests in new verbose mode
 - `check` now comes with a higher level test ("Layer test") that is internally converted into atomic aql tests. The test can be applied to nodes and edges. It tests if a layer exists and only valid annotation values have been used.
+- using flag `--env` allows to resolve environmental variables in workflow definitions which enables the use of template workflow definitions
 
 ### Fixed
 

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -52,7 +52,7 @@ pub struct Workflow {
 use std::convert::TryFrom;
 use toml;
 
-fn contained_variables<'a>(workflow: &'a String) -> Result<Vec<(i32, &'a str)>> {
+fn contained_variables(workflow: &'_ str) -> Result<Vec<(i32, &'_ str)>> {
     let pattern = Regex::new("[$][^\\s\\-/\"'.;,?!]+")?;
     let mut variables = Vec::new();
     for m in pattern.find_iter(workflow) {

--- a/tests/data/import/empty/empty_with_vars.toml
+++ b/tests/data/import/empty/empty_with_vars.toml
@@ -1,0 +1,11 @@
+[[import]]
+path = "tests/data/import/empty"
+format = "$TEST_VAR_FORMAT_NAME"
+
+[import.config]
+
+[[graph_op]]
+action = "$TEST_VAR_GRAPH_OP_NAME"
+
+[graph_op.config]
+tests = []


### PR DESCRIPTION
using flag `--env` allows to resolve environmental variables in workflow definitions which enables the use of template workflow definitions

fixes #104