### PR TITLE
fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - mapping annotations now correctly extracts the id of the node to apply a new annotation to
+- linking nodes failed to extract node names when graphANNIS responded with a node name only (e. g. in case of "tok" or "node" in a query)
 
 ## [0.3.1] - 2023-08-04
 


### PR DESCRIPTION
When a query contains "tok" or "node", for that node no annotation name is contained in the match. In such a case, `retrieve_nodes_with_values` failed to properly extract the node name, which resulted in failed linking and a conversion error. This has been fixed.