### PR TITLE
Fix/link nodes concatenate values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- a separator for joining node values in `link` can be set with attribute `value_sep`
+
 ### Fixed
 
 - mapping annotations now correctly extracts the id of the node to apply a new annotation to
 - linking nodes failed to extract node names when graphANNIS responded with a node name only (e. g. in case of "tok" or "node" in a query)
+- linking nodes did not concatenate the values of multiple nodes properly, this is now fixed
 
 ## [0.3.1] - 2023-08-04
 

--- a/src/manipulator/link_nodes.rs
+++ b/src/manipulator/link_nodes.rs
@@ -130,8 +130,9 @@ fn gather_link_data(
     let node_annos = graph.get_node_annos();
     for group_of_bundles in retrieve_nodes_with_values(cs, query.to_string())? {
         if let Some((_, link_node_name)) = group_of_bundles.get(node_index - 1) {
+            let mut target_data = Vec::new();
+            let mut total_value = String::new();
             for value_index in value_indices {
-                let mut total_value = String::new();
                 if let Some((Some(anno_key), carrying_node_name)) =
                     group_of_bundles.get(*value_index - 1)
                 {
@@ -153,12 +154,9 @@ fn gather_link_data(
                     });
                     sender.send(message)?;
                 }
-                if let Some(node_name_list) = data.get_mut(&total_value) {
-                    node_name_list.push(link_node_name.to_string());
-                } else {
-                    data.insert(total_value, vec![link_node_name.to_string()]);
-                }
+                target_data.push(link_node_name.to_string());
             }
+            data.insert(total_value, target_data);
         } else if let Some(sender) = tx {
             let message = StatusMessage::Failed(AnnattoError::Manipulator {
                 reason: format!(


### PR DESCRIPTION
The total value when joining multiple nodes' annotation values to identify a link source or target node is now computed correctly. Additionally a value separator can be configured via `value_sep`. Its default value is the empty string.