### PR TITLE
Feature/revise components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - graph_op `check` can now be configured to not let the entire processing chain fail, when a test fails, by setting `policy = "warn"` (default is `fail`)
 - metadata can be imported from spreadsheets alongside the linguistic data in the workbook, a data and a metadata spreadsheet name or number can now be specified for importing xlsx
 - add heuristic for KWIC visualizer in graphml export
+- `re` is now `revise`
+- `revise` can modify components
 
 ### Fixed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use importer::{
 };
 use manipulator::{
     check::Check, link_nodes::LinkNodes, map_annos::MapAnnos, merge::Merge, no_op::NoOp,
-    re::Replace, Manipulator,
+    re::Revise, Manipulator,
 };
 use serde_derive::Deserialize;
 
@@ -99,12 +99,12 @@ impl ReadFrom {
 #[derive(Deserialize)]
 #[serde(tag = "action", rename_all = "lowercase", content = "config")]
 pub enum GraphOp {
-    Check(Check),                  // no default, has a (required) path attribute
-    Link(LinkNodes),               // no default, has required attributes
-    Map(MapAnnos),                 // no default, has a (required) path attribute
-    Merge(Merge),                  // no default, has required attributes
-    Re(#[serde(default)] Replace), // does nothing on default
-    None(#[serde(default)] NoOp),  // has no attributes
+    Check(Check),                 // no default, has a (required) path attribute
+    Link(LinkNodes),              // no default, has required attributes
+    Map(MapAnnos),                // no default, has a (required) path attribute
+    Merge(Merge),                 // no default, has required attributes
+    Re(#[serde(default)] Revise), // does nothing on default
+    None(#[serde(default)] NoOp), // has no attributes
 }
 
 impl Default for GraphOp {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub enum GraphOp {
     Link(LinkNodes),              // no default, has required attributes
     Map(MapAnnos),                // no default, has a (required) path attribute
     Merge(Merge),                 // no default, has required attributes
-    Re(#[serde(default)] Revise), // does nothing on default
+    Revise(#[serde(default)] Revise), // does nothing on default
     None(#[serde(default)] NoOp), // has no attributes
 }
 
@@ -127,7 +127,7 @@ impl GraphOp {
             GraphOp::Link(m) => m,
             GraphOp::Map(m) => m,
             GraphOp::Merge(m) => m,
-            GraphOp::Re(m) => m,
+            GraphOp::Revise(m) => m,
             GraphOp::None(m) => m,
         }
     }

--- a/src/manipulator/re.rs
+++ b/src/manipulator/re.rs
@@ -32,9 +32,10 @@ pub struct Replace {
     node_annos: Option<BTreeMap<String, String>>,
     edge_annos: Option<BTreeMap<String, String>>,
     namespaces: Option<BTreeMap<String, String>>,
+    components: Option<BTreeMap<String, String>>,
 }
 
-pub const MODULE_NAME: &str = "replace";
+pub const MODULE_NAME: &str = "revise"; // deprecate feature MODULE_NAME soon
 
 impl Module for Replace {
     fn module_name(&self) -> &str {

--- a/src/manipulator/re.rs
+++ b/src/manipulator/re.rs
@@ -32,7 +32,7 @@ pub struct Replace {
     node_annos: Option<BTreeMap<String, String>>,
     edge_annos: Option<BTreeMap<String, String>>,
     namespaces: Option<BTreeMap<String, String>>,
-    components: Option<BTreeMap<AnnotationComponent, AnnotationComponent>>,
+    components: Option<BTreeMap<String, String>>,
 }
 
 pub const MODULE_NAME: &str = "revise"; // deprecate feature MODULE_NAME soon
@@ -41,6 +41,24 @@ impl Module for Replace {
     fn module_name(&self) -> &str {
         MODULE_NAME
     }
+}
+
+const DELIMITER: &str = "::";
+
+fn parse_component_string(value: &str) -> Result<(AnnotationComponentType, String, String), Box<dyn std::error::Error>> {
+    if let Some((ctype_str, remainder)) = value.split_once(DELIMITER) {
+
+    } else {
+        
+    }
+}
+
+fn to_component_map(str_map: &BTreeMap<String, String>) -> Result<BTreeMap<AnnotationComponent, AnnotationComponent>, Box<dyn std::error::Error>> {
+    let mut component_map = BTreeMap::new();
+    for (old, new) in str_map {
+
+    }
+    Ok(component_map)
 }
 
 fn revise_components() -> Result<(), Box<dyn std::error::Error>> {
@@ -477,6 +495,8 @@ impl Manipulator for Replace {
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
     use std::env::temp_dir;
+    use std::fs;
+    use std::path::Path;
 
     use crate::manipulator::re::Replace;
     use crate::manipulator::Manipulator;
@@ -1668,5 +1688,15 @@ mod tests {
         }
         g.apply_update(&mut u, |_| {})?;
         Ok(g)
+    }
+
+    #[test]
+    fn test_deserialize_map_components() {
+        let path = Path::new("./tests/data/graph_op/re/map_component.toml");
+        let toml_string = fs::read_to_string(path);
+        assert!(toml_string.is_ok(), "Could not read test file: {:?}", path);
+        let r: std::result::Result<BTreeMap<String, String>, toml::de::Error> =
+            toml::from_str(toml_string.unwrap().as_str());
+        assert!(r.is_ok(), "Could not parse test file: {:?}", &r.err());
     }
 }

--- a/src/manipulator/re.rs
+++ b/src/manipulator/re.rs
@@ -645,7 +645,7 @@ mod tests {
     use std::fs;
     use std::path::Path;
 
-    use crate::manipulator::re::{to_component_map, Revise};
+    use crate::manipulator::re::{parse_component_string, to_component_map, Revise};
     use crate::manipulator::Manipulator;
     use crate::Result;
 
@@ -1996,5 +1996,19 @@ mod tests {
             None,
         );
         assert_eq!(target_map, component_map);
+    }
+
+    #[test]
+    fn test_parse_component_string() {
+        assert!(parse_component_string("no_delimiter").is_err());
+        assert!(parse_component_string("invalid_type::layer::name").is_err());
+        assert!(parse_component_string("partof::layer::name").is_ok());
+        assert!(parse_component_string("ordering::layer::name").is_ok());
+        assert!(parse_component_string("coverage::layer::name").is_ok());
+        assert!(parse_component_string("dominance::layer::name").is_ok());
+        assert!(parse_component_string("pointing::layer::name").is_ok());
+        assert!(parse_component_string("l::layer::name").is_ok());
+        assert!(parse_component_string("r::layer::name").is_ok());
+        assert!(parse_component_string("partof::::").is_ok());
     }
 }

--- a/src/manipulator/re.rs
+++ b/src/manipulator/re.rs
@@ -32,7 +32,7 @@ pub struct Replace {
     node_annos: Option<BTreeMap<String, String>>,
     edge_annos: Option<BTreeMap<String, String>>,
     namespaces: Option<BTreeMap<String, String>>,
-    components: Option<BTreeMap<String, String>>,
+    components: Option<BTreeMap<AnnotationComponent, AnnotationComponent>>,
 }
 
 pub const MODULE_NAME: &str = "revise"; // deprecate feature MODULE_NAME soon
@@ -41,6 +41,14 @@ impl Module for Replace {
     fn module_name(&self) -> &str {
         MODULE_NAME
     }
+}
+
+fn revise_components() -> Result<(), Box<dyn std::error::Error>> {
+    Ok(())
+}
+
+fn revise_component() -> Result<(), Box<dyn std::error::Error>> {
+    Ok(())
 }
 
 fn remove_nodes(
@@ -522,6 +530,7 @@ mod tests {
             node_annos: Some(node_map),
             edge_annos: Some(edge_map),
             namespaces: None,
+            components: None,
         };
         let result = replace.manipulate_corpus(&mut g, temp_dir().as_path(), None);
         assert_eq!(result.is_ok(), true, "Probing merge result {:?}", &result);
@@ -655,6 +664,7 @@ mod tests {
             node_annos: Some(node_map),
             edge_annos: None,
             remove_nodes: None,
+            components: None,
         };
         let result = replace.manipulate_corpus(&mut g, temp_dir().as_path(), None);
         assert_eq!(result.is_ok(), true, "Probing merge result {:?}", &result);
@@ -790,6 +800,7 @@ mod tests {
             node_annos: Some(node_map),
             edge_annos: Some(edge_map),
             remove_nodes: None,
+            components: None,
         };
         assert_eq!(
             replace
@@ -844,6 +855,7 @@ mod tests {
             node_annos: Some(node_map),
             edge_annos: Some(edge_map),
             remove_nodes: None,
+            components: None,
         };
         assert_eq!(
             replace
@@ -884,6 +896,7 @@ mod tests {
             node_annos: None,
             edge_annos: None,
             namespaces: Some(ns_map),
+            components: None,
         };
         let op_result = replace.manipulate_corpus(&mut g, temp_dir().as_path(), None);
         assert_eq!(

--- a/src/manipulator/re.rs
+++ b/src/manipulator/re.rs
@@ -1957,6 +1957,7 @@ mod tests {
             "ordering::annis::".to_string(),
             "ordering::::default_ordering".to_string(),
         );
+        name_map.insert("dominance::annis::syntax".to_string(), "".to_string());
         assert_eq!(Some(name_map), revise.components);
         let component_map = to_component_map(revise.components.as_ref().unwrap())
             .map_err(|_| assert!(false))
@@ -1985,6 +1986,14 @@ mod tests {
                 "".into(),
                 "default_ordering".into(),
             )),
+        );
+        target_map.insert(
+            AnnotationComponent::new(
+                AnnotationComponentType::Dominance,
+                ANNIS_NS.into(),
+                "syntax".into(),
+            ),
+            None,
         );
         assert_eq!(target_map, component_map);
     }

--- a/tests/data/graph_op/re/deser_test.toml
+++ b/tests/data/graph_op/re/deser_test.toml
@@ -10,3 +10,4 @@ move_node_annos = true
 [components]
 "ordering::annis::text" = "ordering::default_ns::text"
 "ordering::annis::" = "ordering::::default_ordering"
+"dominance::annis::syntax" = ""

--- a/tests/data/graph_op/re/deser_test.toml
+++ b/tests/data/graph_op/re/deser_test.toml
@@ -1,0 +1,12 @@
+remove_nodes = ["any_weird_node_address"]
+move_node_annos = true
+[node_annos]
+"norm::pos" = "norm::POS"
+"norm::lemma" = "norm::LEMMA"
+[edge_annos]
+"deprel" = "func"
+[namespaces]
+"default_ns" = ""
+[components]
+"ordering::annis::text" = "ordering::default_ns::text"
+"ordering::annis::" = "ordering::::default_ordering"

--- a/tests/data/graph_op/re/map_component.toml
+++ b/tests/data/graph_op/re/map_component.toml
@@ -1,0 +1,3 @@
+"ordering::annis::" = "ordering::::default_ordering"
+"ordering::annis::norm" = "ordering::::norm"
+"partof::annis::" = "dominance::document_structure::contains"


### PR DESCRIPTION
The `re` module is now addressed as `revise`. It can now also modify components (type, layer, and name). Syntax is comparable to name mappings:
```
[graph_op.config.components]
"old_ctype::old_layer::old_name" = "new_ctype::new_layer::new_name"
```
Valid values for ctypes are:

```
partof
ordering
coverage
dominance
pointing
l
r
```

fixes #134 

