### PR TITLE
Embed file names as nodes of an AnnotationGraph (without their content)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add heuristic for KWIC visualizer in graphml export
 - `re` is now `revise`
 - `revise` can modify components
+- `path` as a import format now triggers the embedding of path names as nodes into the graph; this is supposed to help to represent configuration files for ANNIS
 
 ### Fixed
 

--- a/src/importer/exmaralda/mod.rs
+++ b/src/importer/exmaralda/mod.rs
@@ -146,7 +146,7 @@ impl ImportEXMARaLDA {
                                 };
                             time_to_tli_attrs
                                 .entry(time)
-                                .or_insert_with(Vec::default)
+                                .or_default()
                                 .push(attr_map["id"].to_string());
                         }
                         "event" | "abbreviation" => char_buf.clear(),

--- a/src/importer/file_nodes.rs
+++ b/src/importer/file_nodes.rs
@@ -51,7 +51,6 @@ mod tests {
         update::{GraphUpdate, UpdateEvent},
         AnnotationGraph,
     };
-    use graphannis_core::{annostorage::ValueSearch, graph::NODE_NAME_KEY};
 
     use crate::{importer::Importer, StepID};
 

--- a/src/importer/file_nodes.rs
+++ b/src/importer/file_nodes.rs
@@ -1,0 +1,100 @@
+use graphannis::update::{GraphUpdate, UpdateEvent};
+use normpath::PathExt;
+use serde_derive::Deserialize;
+
+use crate::Module;
+
+use super::Importer;
+
+#[derive(Deserialize, Default)]
+pub struct CreateFileNodes {}
+
+impl Importer for CreateFileNodes {
+    fn import_corpus(
+        &self,
+        input_path: &std::path::Path,
+        _step_id: crate::StepID,
+        _tx: Option<crate::workflow::StatusSender>,
+    ) -> Result<GraphUpdate, Box<dyn std::error::Error>> {
+        let mut update = GraphUpdate::default();
+        let base_dir = input_path.normalize()?;
+        let base_dir_name = base_dir.file_name().unwrap();
+        let start_index = base_dir.as_path().to_string_lossy().len() - base_dir_name.len();
+        for path_r in glob::glob(format!("{}/**/*", base_dir.as_path().to_string_lossy()).as_str())?
+        {
+            let path = path_r?;
+            let node_name = path.to_str().unwrap()[start_index..].to_string();
+            if path.is_file() {
+                update.add_event(UpdateEvent::AddNode {
+                    node_name,
+                    node_type: "file".to_string(),
+                })?;
+            }
+        }
+        Ok(update)
+    }
+}
+
+const MODULE_NAME: &str = "embed_files";
+
+impl Module for CreateFileNodes {
+    fn module_name(&self) -> &str {
+        MODULE_NAME
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use graphannis::{
+        update::{GraphUpdate, UpdateEvent},
+        AnnotationGraph,
+    };
+    use graphannis_core::{annostorage::ValueSearch, graph::NODE_NAME_KEY};
+
+    use crate::{importer::Importer, StepID};
+
+    use super::{CreateFileNodes, MODULE_NAME};
+
+    #[test]
+    fn test_file_nodes_in_mem() {
+        let r = test(false);
+        assert!(r.is_ok(), "test ended with error: {:?}", r.err());
+    }
+
+    #[test]
+    fn test_files_nodes_on_disk() {
+        let r = test(true);
+        assert!(r.is_ok(), "test ended with error: {:?}", r.err());
+    }
+
+    fn test(on_disk: bool) -> Result<(), Box<dyn std::error::Error>> {
+        let mut expected_g = AnnotationGraph::new(on_disk)?;
+        let mut u = GraphUpdate::default();
+        u.add_event(UpdateEvent::AddNode {
+            node_name: "xlsx/test_file.xlsx".to_string(),
+            node_type: "file".to_string(),
+        })?;
+        let eur = expected_g.apply_update(&mut u, |_| {});
+        assert!(eur.is_err()); // ordering component is missing, so this should be an error
+        let mut test_g = AnnotationGraph::new(on_disk)?;
+        let import = CreateFileNodes::default();
+        let mut test_u = import.import_corpus(
+            Path::new("tests/data/import/xlsx/clean/xlsx/"),
+            StepID {
+                module_name: MODULE_NAME.to_string(),
+                path: None,
+            },
+            None,
+        )?;
+        let ur = test_g.apply_update(&mut test_u, |_| {});
+        assert!(ur.is_err()); // ordering component is missing, so this should be an error
+        let expected_id = expected_g.get_node_id_from_name("xlsx/test_file.xlsx")?;
+        assert!(expected_id.is_some());
+        let test_id = test_g.get_node_id_from_name("xlsx/test_file.xlsx")?;
+        assert!(test_id.is_some());
+        assert_eq!(expected_id.unwrap(), test_id.unwrap());
+        Ok(())
+    }
+}

--- a/src/importer/mod.rs
+++ b/src/importer/mod.rs
@@ -3,6 +3,7 @@
 pub mod conllu;
 pub mod corpus_annotations;
 pub mod exmaralda;
+pub mod file_nodes;
 pub mod graphml;
 pub mod ptb;
 pub mod spreadsheet;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@ use error::Result;
 use exporter::{graphml::GraphMLExporter, Exporter};
 use importer::{
     conllu::ImportCoNLLU, corpus_annotations::AnnotateCorpus, exmaralda::ImportEXMARaLDA,
-    graphml::GraphMLImporter, ptb::PtbImporter, spreadsheet::ImportSpreadsheet,
-    textgrid::TextgridImporter, CreateEmptyCorpus, Importer,
+    file_nodes::CreateFileNodes, graphml::GraphMLImporter, ptb::PtbImporter,
+    spreadsheet::ImportSpreadsheet, textgrid::TextgridImporter, CreateEmptyCorpus, Importer,
 };
 use manipulator::{
     check::Check, link_nodes::LinkNodes, map_annos::MapAnnos, merge::Merge, no_op::NoOp,
@@ -63,6 +63,7 @@ pub enum ReadFrom {
     GraphML(#[serde(default)] GraphMLImporter),
     Meta(#[serde(default)] AnnotateCorpus),
     None(#[serde(default)] CreateEmptyCorpus),
+    Path(#[serde(default)] CreateFileNodes),
     PTB(#[serde(default)] PtbImporter),
     TextGrid(#[serde(default)] TextgridImporter),
     Xlsx(#[serde(default)] ImportSpreadsheet),
@@ -92,6 +93,7 @@ impl ReadFrom {
             ReadFrom::Meta(m) => m,
             ReadFrom::Xlsx(m) => m,
             ReadFrom::GraphML(m) => m,
+            ReadFrom::Path(m) => m,
         }
     }
 }

--- a/src/manipulator/re.rs
+++ b/src/manipulator/re.rs
@@ -86,7 +86,7 @@ fn to_component_map(
             return Err(AnnattoError::Manipulator {
                 reason: format!("Could not parse source component: {old}"),
                 manipulator: MODULE_NAME.to_string(),
-            })?;
+            });
         }
     }
     Ok(component_map)


### PR DESCRIPTION
GraphML for ANNIS represents configuration files with their path as node name and type `file`. When the import format is set to "path", every file is embedded this way. This PR only provides the embedding component. The issue of copying the files (and first finding them for that purpose) is not solved, therefore #135 should not be closed.