### PR TITLE
add annis::file annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `re` is now `revise`
 - `revise` can modify components
 - `path` as a import format now triggers the embedding of path names as nodes into the graph; this is supposed to help to represent configuration files for ANNIS
+- import `path` adds an `annis::file` annotation
 
 ### Fixed
 


### PR DESCRIPTION
Importing files as path nodes (`format = "path"`) now adds an `annis::file` annotation. #135 