### PR TITLE
better ids for hypernodes #174

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - graph_op `collapse` can collapse an edge component, i. e., it merges all nodes in a connected subgraph in said component
 - `collapse` can be accelerated when all edges of the component to be collapsed are known to be disjoint by providing `disjoint = true` in the step config
 - `collapse` provides more feedback on current process
+- `collapse` gives hypernodes proper names that allow to identify the subgraph they belong to. Furthermore already existing hypernode ids are not reused (in case multiple collapse operations are run on a graph).
 
 ### Fixed
 

--- a/tests/data/graph_op/collapse/test_check.toml
+++ b/tests/data/graph_op/collapse/test_check.toml
@@ -1,4 +1,9 @@
 [[tests]]
+query = "node_name=/corpus#hypernode.*/"
+expected = 5
+description = "Hypernodes were successfully created"
+
+[[tests]]
 query = "a:anno"
 expected = 5
 description = "There are five nodes with anno a"

--- a/tests/data/graph_op/collapse/test_check_disjoint.toml
+++ b/tests/data/graph_op/collapse/test_check_disjoint.toml
@@ -1,4 +1,9 @@
 [[tests]]
+query = "node_name=/.*hypernode.*/"
+expected = 5
+description = "Hypernodes were successfully created"
+
+[[tests]]
 query = "a:anno"
 expected = 5
 description = "There are five nodes with anno a"


### PR DESCRIPTION
`collapse` gives hypernodes proper names that allow to identify the subgraph they belong to. Furthermore already existing hypernode ids are not reused (in case multiple collapse operations are run on a graph).