### PR TITLE
Feature/revise rename nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - progress reports for `enumerate`, `link`, and `map`
+- `revise` can now rename nodes using attribute `node_names`, e. g. for renaming (top level) corpus nodes. The syntax is equivalent to renaming annotations, thus renaming with an empty value will lead to deletion. Renaming with an existing value (also rename with self) will lead to an error.
 
 ### Changed
 

--- a/src/manipulator/re.rs
+++ b/src/manipulator/re.rs
@@ -621,7 +621,7 @@ fn rename_nodes(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let node_annos = graph.get_node_annos();
     let trimmed_old_name = old_name.trim();
-    if node_annos.has_node_name(&trimmed_old_name)? {
+    if node_annos.has_node_name(trimmed_old_name)? {
         let trimmed_new_name = new_name.trim();
         if trimmed_new_name.is_empty() {
             // deletion by rename

--- a/src/manipulator/re.rs
+++ b/src/manipulator/re.rs
@@ -615,8 +615,8 @@ fn read_replace_property_value(
 fn rename_nodes(
     graph: &AnnotationGraph,
     update: &mut GraphUpdate,
-    old_name: &String,
-    new_name: &String,
+    old_name: &str,
+    new_name: &str,
     step_id: &StepID,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let node_annos = graph.get_node_annos();

--- a/src/manipulator/snapshots/annatto__manipulator__re__tests__deletion_by_rename.snap
+++ b/src/manipulator/snapshots/annatto__manipulator__re__tests__deletion_by_rename.snap
@@ -1,0 +1,82 @@
+---
+source: src/manipulator/re.rs
+expression: graphml
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<graphml>
+    <key id="k0" for="graph" attr.name="configuration" attr.type="string"/>
+    <key id="k1" for="node" attr.name="lemma" attr.type="string"/>
+    <key id="k2" for="node" attr.name="annis::node_type" attr.type="string"/>
+    <key id="k3" for="node" attr.name="pos" attr.type="string"/>
+    <key id="k4" for="node" attr.name="text" attr.type="string"/>
+    <key id="k5" for="node" attr.name="annis::tok" attr.type="string"/>
+    <key id="k6" for="node" attr.name="deprel" attr.type="string"/>
+    <graph edgedefault="directed" parse.order="nodesfirst" parse.nodeids="free" parse.edgeids="canonical">
+        <data key="k0"><![CDATA[
+# configure visualizations here
+]]></data>
+        <node id="root">
+            <data key="k2">corpus</data>
+        </node>
+        <node id="root/b/doc">
+            <data key="k2">corpus</data>
+        </node>
+        <node id="root/b/doc#t1">
+            <data key="k1">I</data>
+            <data key="k2">node</data>
+            <data key="k3">PRON</data>
+            <data key="k4">I</data>
+            <data key="k5">I</data>
+        </node>
+        <node id="root/b/doc#t2">
+            <data key="k1">be</data>
+            <data key="k2">node</data>
+            <data key="k3">VERB</data>
+            <data key="k4">am</data>
+            <data key="k5">am</data>
+        </node>
+        <node id="root/b/doc#t3">
+            <data key="k1">in</data>
+            <data key="k2">node</data>
+            <data key="k3">ADP</data>
+            <data key="k4">in</data>
+            <data key="k5">in</data>
+        </node>
+        <node id="root/b/doc#t4">
+            <data key="k1">Berlin</data>
+            <data key="k2">node</data>
+            <data key="k3">PROPN</data>
+            <data key="k4">Berlin</data>
+            <data key="k5">Berlin</data>
+        </node>
+        <edge id="e0" source="root/b/doc#t2" target="root/b/doc#t1" label="Pointing/syntax/dep">
+            <data key="k6">subj</data>
+        </edge>
+        <edge id="e1" source="root/b/doc#t2" target="root/b/doc#t3" label="Pointing/syntax/dep">
+            <data key="k6">comp:pred</data>
+        </edge>
+        <edge id="e2" source="root/b/doc#t3" target="root/b/doc#t4" label="Pointing/syntax/dep">
+            <data key="k6">comp:obj</data>
+        </edge>
+        <edge id="e3" source="root/b/doc#t1" target="root/b/doc#t2" label="Ordering/annis/">
+        </edge>
+        <edge id="e4" source="root/b/doc#t2" target="root/b/doc#t3" label="Ordering/annis/">
+        </edge>
+        <edge id="e5" source="root/b/doc#t3" target="root/b/doc#t4" label="Ordering/annis/">
+        </edge>
+        <edge id="e6" source="root/b/doc#t1" target="root/b/doc#t2" label="Ordering/annis/text">
+        </edge>
+        <edge id="e7" source="root/b/doc#t2" target="root/b/doc#t3" label="Ordering/annis/text">
+        </edge>
+        <edge id="e8" source="root/b/doc#t3" target="root/b/doc#t4" label="Ordering/annis/text">
+        </edge>
+        <edge id="e9" source="root/b/doc#t1" target="root/b/doc" label="PartOf/annis/">
+        </edge>
+        <edge id="e10" source="root/b/doc#t2" target="root/b/doc" label="PartOf/annis/">
+        </edge>
+        <edge id="e11" source="root/b/doc#t3" target="root/b/doc" label="PartOf/annis/">
+        </edge>
+        <edge id="e12" source="root/b/doc#t4" target="root/b/doc" label="PartOf/annis/">
+        </edge>
+    </graph>
+</graphml>

--- a/src/manipulator/snapshots/annatto__manipulator__re__tests__rename_corpus_node.snap
+++ b/src/manipulator/snapshots/annatto__manipulator__re__tests__rename_corpus_node.snap
@@ -1,0 +1,89 @@
+---
+source: src/manipulator/re.rs
+expression: graphml
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<graphml>
+    <key id="k0" for="graph" attr.name="configuration" attr.type="string"/>
+    <key id="k1" for="node" attr.name="lemma" attr.type="string"/>
+    <key id="k2" for="node" attr.name="annis::node_type" attr.type="string"/>
+    <key id="k3" for="node" attr.name="pos" attr.type="string"/>
+    <key id="k4" for="node" attr.name="text" attr.type="string"/>
+    <key id="k5" for="node" attr.name="annis::tok" attr.type="string"/>
+    <key id="k6" for="node" attr.name="deprel" attr.type="string"/>
+    <graph edgedefault="directed" parse.order="nodesfirst" parse.nodeids="free" parse.edgeids="canonical">
+        <data key="k0"><![CDATA[
+# configure visualizations here
+]]></data>
+        <node id="corpus">
+            <data key="k2">corpus</data>
+        </node>
+        <node id="corpus/subcorpus">
+            <data key="k2">corpus</data>
+        </node>
+        <node id="root/b/doc">
+            <data key="k2">corpus</data>
+        </node>
+        <node id="root/b/doc#t1">
+            <data key="k1">I</data>
+            <data key="k2">node</data>
+            <data key="k3">PRON</data>
+            <data key="k4">I</data>
+            <data key="k5">I</data>
+        </node>
+        <node id="root/b/doc#t2">
+            <data key="k1">be</data>
+            <data key="k2">node</data>
+            <data key="k3">VERB</data>
+            <data key="k4">am</data>
+            <data key="k5">am</data>
+        </node>
+        <node id="root/b/doc#t3">
+            <data key="k1">in</data>
+            <data key="k2">node</data>
+            <data key="k3">ADP</data>
+            <data key="k4">in</data>
+            <data key="k5">in</data>
+        </node>
+        <node id="root/b/doc#t4">
+            <data key="k1">Berlin</data>
+            <data key="k2">node</data>
+            <data key="k3">PROPN</data>
+            <data key="k4">Berlin</data>
+            <data key="k5">Berlin</data>
+        </node>
+        <edge id="e0" source="root/b/doc#t2" target="root/b/doc#t1" label="Pointing/syntax/dep">
+            <data key="k6">subj</data>
+        </edge>
+        <edge id="e1" source="root/b/doc#t2" target="root/b/doc#t3" label="Pointing/syntax/dep">
+            <data key="k6">comp:pred</data>
+        </edge>
+        <edge id="e2" source="root/b/doc#t3" target="root/b/doc#t4" label="Pointing/syntax/dep">
+            <data key="k6">comp:obj</data>
+        </edge>
+        <edge id="e3" source="root/b/doc#t1" target="root/b/doc#t2" label="Ordering/annis/">
+        </edge>
+        <edge id="e4" source="root/b/doc#t2" target="root/b/doc#t3" label="Ordering/annis/">
+        </edge>
+        <edge id="e5" source="root/b/doc#t3" target="root/b/doc#t4" label="Ordering/annis/">
+        </edge>
+        <edge id="e6" source="root/b/doc#t1" target="root/b/doc#t2" label="Ordering/annis/text">
+        </edge>
+        <edge id="e7" source="root/b/doc#t2" target="root/b/doc#t3" label="Ordering/annis/text">
+        </edge>
+        <edge id="e8" source="root/b/doc#t3" target="root/b/doc#t4" label="Ordering/annis/text">
+        </edge>
+        <edge id="e9" source="corpus/subcorpus" target="corpus" label="PartOf/annis/">
+        </edge>
+        <edge id="e10" source="root/b/doc" target="corpus/subcorpus" label="PartOf/annis/">
+        </edge>
+        <edge id="e11" source="root/b/doc#t1" target="root/b/doc" label="PartOf/annis/">
+        </edge>
+        <edge id="e12" source="root/b/doc#t2" target="root/b/doc" label="PartOf/annis/">
+        </edge>
+        <edge id="e13" source="root/b/doc#t3" target="root/b/doc" label="PartOf/annis/">
+        </edge>
+        <edge id="e14" source="root/b/doc#t4" target="root/b/doc" label="PartOf/annis/">
+        </edge>
+    </graph>
+</graphml>


### PR DESCRIPTION
`revise` can now rename nodes using attribute `node_names`, e. g. for renaming (top level) corpus nodes. The syntax is equivalent to renaming annotations, thus renaming with an empty value will lead to deletion. Renaming with an existing value (also rename with self) will lead to an error.