### PR TITLE
Fix/deny unknown fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `xlsx` importer did not give the correct node name to segmentation token. Due
   to this inconsistency, span annotations on segmentation nodes where not
   connected to the segmentation token.
+- unknown keys in toml configurations are now denied not only in config context, but globally in a workflow file
 
 ## [0.16.0] - 2024-09-02
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,6 +452,7 @@ impl Display for StepID {
 pub trait Step {}
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ImporterStep {
     #[serde(flatten)]
     module: ReadFrom,
@@ -473,6 +474,7 @@ impl ImporterStep {
 impl Step for ImporterStep {}
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ExporterStep {
     #[serde(flatten)]
     module: WriteAs,
@@ -495,6 +497,7 @@ impl ExporterStep {
 impl Step for ExporterStep {}
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ManipulatorStep {
     #[serde(flatten)]
     module: GraphOp,

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -45,6 +45,7 @@ pub enum StatusMessage {
 /// The manipulators are executed in their defined sequence and can change the annotation graph.
 /// Last, all exporters are called with the now read-only annotation graph in parallel.
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Workflow {
     import: Vec<ImporterStep>,
     graph_op: Option<Vec<ManipulatorStep>>,


### PR DESCRIPTION
Toml workflow files now have to strictly conform to expected keys. Until now this behaviour was only applied in the config section of a module, i. e. using keys that map to field names, that were not valid names, they were not ignored, but denied. Unfortunately, when accidentally placing a config key outside of the config section by accident, this went unnoticed, as the outer context did not deny unknown fields. This has now been fixed.