### PR TITLE
Treetagger export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `enumerate`: Enumerate can be sort to additionally sort results before enumerating, node values can be interpreted as numeric if required
-- `treetagger` exporter that can output base token, segmentation token and document metadata. Spans are not exported yet.
+- `treetagger` exporter that can output base token, segmentation token and document metadata.
 
 ## [0.37.1] - 2025-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `enumerate`: Enumerate can be sort to additionally sort results before enumerating, node values can be interpreted as numeric if required
+- `treetagger` exporter that can output base token, segmentation token and document metadata. Spans are not exported yet.
 
 ## [0.37.1] - 2025-07-23
 
@@ -113,7 +114,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- import `xlsx`: empty column map to be valid 
+- import `xlsx`: empty column map to be valid
 - all imports: corpus node names keep trailing sequences starting with a dot if derived from a path, extensions are only stripped off file names
 
 ### Changed
@@ -285,9 +286,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add new `table` importer for CSV files.
 - Allow to set the order of output columns in `table` export with the parameter
-  `column_names` and to skip the column header with the `skip_header` param. 
+  `column_names` and to skip the column header with the `skip_header` param.
 - `remove_match` option in `revise` now allows to delete the annotation but not
-  the referenced node. 
+  the referenced node.
 
 ### Fixed
 
@@ -295,7 +296,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exporting the token with the `skip_token` parameter.
 - Fixed `find_connected` calls with `Bound::Included(usize::MAX)`, which can
   lead to invalid results when using the linear graph storage. Replaced with the
-  correct `Bound::Unbounded`. 
+  correct `Bound::Unbounded`.
 
 ## [0.17.0] - 2024-09-27
 

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -8,6 +8,7 @@ pub mod saltxml;
 pub mod sequence;
 pub(crate) mod table;
 pub mod textgrid;
+pub mod treetagger;
 pub mod xlsx;
 
 use crate::{StepID, workflow::StatusSender};

--- a/src/exporter/saltxml/document.rs
+++ b/src/exporter/saltxml/document.rs
@@ -346,13 +346,12 @@ impl SaltDocumentGraphMapper {
         let corpus_graph_helper = CorpusGraphHelper::new(graph);
 
         let mut timeline_ordering = None;
-        if ordering_components.len() > 1 {
-            if let Some(idx) = ordering_components
+        if ordering_components.len() > 1
+            && let Some(idx) = ordering_components
                 .iter()
                 .position(|c| c.name.is_empty() && c.layer == ANNIS_NS)
-            {
-                timeline_ordering = Some(ordering_components.remove(idx));
-            }
+        {
+            timeline_ordering = Some(ordering_components.remove(idx));
         };
 
         let document_node_name = graph

--- a/src/exporter/snapshots/annatto__exporter__treetagger__tests__core.snap
+++ b/src/exporter/snapshots/annatto__exporter__treetagger__tests__core.snap
@@ -4,15 +4,15 @@ expression: export.unwrap()
 ---
 ---- doc1.tt:
 <doc author="&lt;unknown&gt;" year="1984">
-Is
-this
-example
-more
-complicated
-than
-it
-appears
-to
-be
-?
+Is	VBZ	be
+this	DT	this
+example	NN	example
+more	RBR	more
+complicated	JJ	complicated
+than	IN	than
+it	PP	it
+appears	VBZ	appear
+to	TO	to
+be	VB	be
+?	SENT	?
 </doc>

--- a/src/exporter/snapshots/annatto__exporter__treetagger__tests__core.snap
+++ b/src/exporter/snapshots/annatto__exporter__treetagger__tests__core.snap
@@ -1,0 +1,13 @@
+---
+source: src/exporter/treetagger.rs
+expression: export.unwrap()
+---
+---- zossen.tt:
+Die
+Jugendlichen
+in
+Zossen
+wollen
+ein
+Musikcafé
+.

--- a/src/exporter/snapshots/annatto__exporter__treetagger__tests__core_no_metadata.snap
+++ b/src/exporter/snapshots/annatto__exporter__treetagger__tests__core_no_metadata.snap
@@ -3,7 +3,6 @@ source: src/exporter/treetagger.rs
 expression: export.unwrap()
 ---
 ---- doc1.tt:
-<doc author="&lt;unknown&gt;" year="1984">
 Is
 this
 example
@@ -15,4 +14,3 @@ appears
 to
 be
 ?
-</doc>

--- a/src/exporter/snapshots/annatto__exporter__treetagger__tests__core_no_metadata.snap
+++ b/src/exporter/snapshots/annatto__exporter__treetagger__tests__core_no_metadata.snap
@@ -3,14 +3,14 @@ source: src/exporter/treetagger.rs
 expression: export.unwrap()
 ---
 ---- doc1.tt:
-Is
-this
-example
-more
-complicated
-than
-it
-appears
-to
-be
-?
+Is	VBZ	be
+this	DT	this
+example	NN	example
+more	RBR	more
+complicated	JJ	complicated
+than	IN	than
+it	PP	it
+appears	VBZ	appear
+to	TO	to
+be	VB	be
+?	SENT	?

--- a/src/exporter/snapshots/annatto__exporter__treetagger__tests__segmentation.snap
+++ b/src/exporter/snapshots/annatto__exporter__treetagger__tests__segmentation.snap
@@ -1,0 +1,11 @@
+---
+source: src/exporter/treetagger.rs
+expression: export.unwrap()
+---
+---- doc1.tt:
+<doc author="&lt;unknown&gt;" year="1984">
+An		
+other		
+example		
+text		
+</doc>

--- a/src/exporter/table.rs
+++ b/src/exporter/table.rs
@@ -399,7 +399,7 @@ impl ExportTable {
         &self,
         graph: &AnnotationGraph,
         node: NodeID,
-    ) -> Result<(Vec<SingleEdgeData>, Vec<SingleEdgeData>), anyhow::Error> {
+    ) -> Result<(Vec<SingleEdgeData<'_>>, Vec<SingleEdgeData<'_>>), anyhow::Error> {
         let mut sources: Vec<SingleEdgeData> = Vec::new();
         let mut targets: Vec<SingleEdgeData> = Vec::new();
         for component in &self.ingoing {

--- a/src/exporter/treetagger.rs
+++ b/src/exporter/treetagger.rs
@@ -227,7 +227,7 @@ impl ExportTreeTagger {
                     .unwrap_or_default();
                 write!(w, "\t{anno_value}")?;
             }
-            write!(w, "\n")?;
+            writeln!(w)?;
         }
 
         if let Some(footer) = footer {

--- a/src/exporter/treetagger.rs
+++ b/src/exporter/treetagger.rs
@@ -353,7 +353,7 @@ impl ExportTreeTagger {
             .collect();
         let first_name = keys
             .first()
-            .map(|key| key.name.to_string())
+            .map(|key| quick_xml::escape::escape(&key.name).to_string())
             .unwrap_or_else(|| "span".to_string());
         Ok(first_name)
     }

--- a/src/exporter/treetagger.rs
+++ b/src/exporter/treetagger.rs
@@ -1,0 +1,222 @@
+use std::{
+    collections::{BTreeMap, btree_map::Entry},
+    fs::File,
+    io::{BufWriter, Write},
+    path::Path,
+};
+
+use anyhow::anyhow;
+use documented::{Documented, DocumentedFields};
+use graphannis::{
+    AnnotationGraph,
+    graph::{AnnoKey, NodeID},
+    model::{AnnotationComponent, AnnotationComponentType},
+};
+use graphannis_core::{
+    dfs::CycleSafeDFS,
+    graph::{ANNIS_NS, DEFAULT_NS, NODE_NAME_KEY},
+};
+use linked_hash_set::LinkedHashSet;
+use serde::{Deserialize, Serialize};
+use struct_field_names_as_array::FieldNamesAsSlice;
+
+use super::Exporter;
+
+use crate::progress::ProgressReporter;
+
+/// Exporter for the file format used by the TreeTagger.
+#[derive(
+    Deserialize, Documented, DocumentedFields, FieldNamesAsSlice, Serialize, Clone, PartialEq,
+)]
+#[serde(deny_unknown_fields)]
+pub struct ExportTreeTagger {
+    /// If given, use this segmentation instead of the token as token column.
+    #[serde(default)]
+    segmentation: Option<String>,
+    /// The provided annotation key defines which nodes within the part-of component define a document. All nodes holding said annotation
+    /// will be exported to a file with the name according to the annotation value. Therefore annotation values must not contain path
+    /// delimiters.
+    ///
+    /// Example:
+    /// ```toml
+    /// [export.config]
+    /// doc_anno = "my_namespace::document"
+    /// ```
+    ///
+    /// The default is `annis::doc`.
+    #[serde(default = "default_doc_anno", with = "crate::estarde::anno_key")]
+    doc_anno: AnnoKey,
+}
+
+fn default_doc_anno() -> AnnoKey {
+    AnnoKey {
+        name: "doc".into(),
+        ns: ANNIS_NS.into(),
+    }
+}
+
+impl Default for ExportTreeTagger {
+    fn default() -> Self {
+        Self {
+            segmentation: None,
+            doc_anno: default_doc_anno(),
+        }
+    }
+}
+
+const FILE_EXTENSION: &str = "tt";
+
+impl Exporter for ExportTreeTagger {
+    fn export_corpus(
+        &self,
+        graph: &graphannis::AnnotationGraph,
+        output_path: &std::path::Path,
+        step_id: crate::StepID,
+        tx: Option<crate::workflow::StatusSender>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let _progress = ProgressReporter::new_unknown_total_work(tx.clone(), step_id.clone())?;
+
+        let base_ordering = AnnotationComponent::new(
+            AnnotationComponentType::Ordering,
+            ANNIS_NS.into(),
+            "".into(),
+        );
+
+        let selected_ordering = if let Some(seg) = &self.segmentation {
+            let matching_components =
+                graph.get_all_components(Some(AnnotationComponentType::Ordering), Some(seg));
+            if matching_components.len() == 1 {
+                matching_components[0].clone()
+            } else if let Some(c) = matching_components.iter().find(|c| c.layer.as_str() == seg) {
+                c.clone()
+            } else if let Some(c) = matching_components
+                .iter()
+                .find(|c| c.layer.as_str() == ANNIS_NS)
+            {
+                c.clone()
+            } else if let Some(c) = matching_components
+                .iter()
+                .find(|c| c.layer.as_str() == DEFAULT_NS)
+            {
+                c.clone()
+            } else {
+                base_ordering
+            }
+        } else {
+            base_ordering
+        };
+
+        let gs_ordering = graph
+            .get_graphstorage(&selected_ordering)
+            .ok_or(anyhow!("Storage of ordering component unavailable"))?;
+        let part_of_storage = graph
+            .get_graphstorage(&AnnotationComponent::new(
+                AnnotationComponentType::PartOf,
+                ANNIS_NS.into(),
+                "".into(),
+            ))
+            .ok_or(anyhow!("Part-of storage unavailable."))?;
+
+        let mut doc_node_to_start = BTreeMap::new();
+        for node in gs_ordering.root_nodes() {
+            let node = node?;
+            let dfs = CycleSafeDFS::new(
+                part_of_storage.as_edgecontainer(),
+                node,
+                0,
+                NodeID::MAX as usize,
+            );
+            for nxt in dfs {
+                let n = nxt?.node;
+                if graph
+                    .get_node_annos()
+                    .has_value_for_item(&n, &self.doc_anno)
+                    .unwrap_or_default()
+                {
+                    if let Entry::Vacant(e) = doc_node_to_start.entry(n) {
+                        e.insert(node);
+                        break;
+                    } else {
+                        let doc_node_name = graph
+                            .get_node_annos()
+                            .get_value_for_item(&n, &NODE_NAME_KEY)?
+                            .unwrap_or_default();
+                        return Err(anyhow!(
+                            "Document {doc_node_name} has more than one start node for base ordering."
+                        )
+                        .into());
+                    }
+                }
+            }
+        }
+        let progress = ProgressReporter::new(tx, step_id, doc_node_to_start.len())?;
+        progress.info(&format!("Exporting {} documents", doc_node_to_start.len()))?;
+        doc_node_to_start
+            .into_iter()
+            .try_for_each(move |(doc, start)| -> anyhow::Result<()> {
+                self.export_document(graph, output_path, doc, start)?;
+                progress.worked(1)?;
+                Ok(())
+            })?;
+        Ok(())
+    }
+
+    fn file_extension(&self) -> &str {
+        FILE_EXTENSION
+    }
+}
+
+impl ExportTreeTagger {
+    fn export_document(
+        &self,
+        graph: &AnnotationGraph,
+        corpus_path: &Path,
+        doc_node: NodeID,
+        start_node: NodeID,
+    ) -> Result<(), anyhow::Error> {
+        let node_annos = graph.get_node_annos();
+        let doc_node_name = node_annos
+            .get_value_for_item(&doc_node, &self.doc_anno)?
+            .ok_or(anyhow!("Could not determine document node name."))?;
+        let file_path =
+            Path::new(corpus_path).join(format!("{doc_node_name}.{}", self.file_extension()));
+        let mut writer = BufWriter::new(File::create(file_path)?);
+        writer.write("Not implemented yet".as_bytes())?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_snapshot;
+
+    use super::*;
+    use crate::{
+        StepID,
+        importer::{Importer as _, exmaralda::ImportEXMARaLDA},
+        test_util::export_to_string,
+    };
+    use std::path::Path;
+
+    #[test]
+    fn core() {
+        let exmaralda = ImportEXMARaLDA {};
+        let import = exmaralda.import_corpus(
+            Path::new("tests/data/import/exmaralda/clean/import/exmaralda/"),
+            StepID {
+                module_name: "test_import_exb".to_string(),
+                path: None,
+            },
+            None,
+        );
+        assert!(import.is_ok());
+        let mut update_import = import.unwrap();
+        let g = AnnotationGraph::with_default_graphstorages(true);
+        assert!(g.is_ok());
+        let mut graph = g.unwrap();
+        assert!(graph.apply_update(&mut update_import, |_| {}).is_ok());
+        let export = export_to_string(&graph, ExportTreeTagger::default());
+        assert!(export.is_ok(), "error: {:?}", export.err());
+        assert_snapshot!(export.unwrap());
+    }
+}

--- a/src/exporter/treetagger/snapshots/annatto__exporter__treetagger__tests__core.snap
+++ b/src/exporter/treetagger/snapshots/annatto__exporter__treetagger__tests__core.snap
@@ -1,0 +1,22 @@
+---
+source: src/exporter/treetagger/tests.rs
+expression: export.unwrap()
+---
+---- doc1.tt:
+<doc author="&lt;unknown&gt;" year="1984">
+<something something="annotated">
+Is	VBZ	be
+this	DT	this
+<anotherthing anotherthing="annotated" evenmore="&lt;unknown-values&gt;">
+example	NN	example
+</something>
+more	RBR	more
+</anotherthing>
+complicated	JJ	complicated
+than	IN	than
+it	PP	it
+appears	VBZ	appear
+to	TO	to
+be	VB	be
+?	SENT	?
+</doc>

--- a/src/exporter/treetagger/snapshots/annatto__exporter__treetagger__tests__core_different_doc_name.snap
+++ b/src/exporter/treetagger/snapshots/annatto__exporter__treetagger__tests__core_different_doc_name.snap
@@ -1,0 +1,24 @@
+---
+source: src/exporter/treetagger/tests.rs
+expression: export.unwrap()
+---
+---- root.tt:
+<doc corpus-name="root">
+<something something="annotated">
+Is	VBZ	be
+this	DT	this
+<anotherthing anotherthing="annotated" evenmore="&lt;unknown-values&gt;">
+example	NN	example
+</something>
+more	RBR	more
+</anotherthing>
+complicated	JJ	complicated
+<span>
+than	IN	than
+</span>
+it	PP	it
+appears	VBZ	appear
+to	TO	to
+be	VB	be
+?	SENT	?
+</doc>

--- a/src/exporter/treetagger/snapshots/annatto__exporter__treetagger__tests__core_no_metadata.snap
+++ b/src/exporter/treetagger/snapshots/annatto__exporter__treetagger__tests__core_no_metadata.snap
@@ -12,7 +12,9 @@ example	NN	example
 more	RBR	more
 </anotherthing>
 complicated	JJ	complicated
+<span>
 than	IN	than
+</span>
 it	PP	it
 appears	VBZ	appear
 to	TO	to

--- a/src/exporter/treetagger/snapshots/annatto__exporter__treetagger__tests__core_no_metadata.snap
+++ b/src/exporter/treetagger/snapshots/annatto__exporter__treetagger__tests__core_no_metadata.snap
@@ -1,0 +1,20 @@
+---
+source: src/exporter/treetagger/tests.rs
+expression: export.unwrap()
+---
+---- doc1.tt:
+<something something="annotated">
+Is	VBZ	be
+this	DT	this
+<anotherthing anotherthing="annotated" evenmore="&lt;unknown-values&gt;">
+example	NN	example
+</something>
+more	RBR	more
+</anotherthing>
+complicated	JJ	complicated
+than	IN	than
+it	PP	it
+appears	VBZ	appear
+to	TO	to
+be	VB	be
+?	SENT	?

--- a/src/exporter/treetagger/snapshots/annatto__exporter__treetagger__tests__core_no_spans.snap
+++ b/src/exporter/treetagger/snapshots/annatto__exporter__treetagger__tests__core_no_spans.snap
@@ -4,18 +4,12 @@ expression: export.unwrap()
 ---
 ---- doc1.tt:
 <doc author="&lt;unknown&gt;" year="1984">
-<something something="annotated">
 Is	VBZ	be
 this	DT	this
-<anotherthing anotherthing="annotated" evenmore="&lt;unknown-values&gt;">
 example	NN	example
-</something>
 more	RBR	more
-</anotherthing>
 complicated	JJ	complicated
-<span>
 than	IN	than
-</span>
 it	PP	it
 appears	VBZ	appear
 to	TO	to

--- a/src/exporter/treetagger/snapshots/annatto__exporter__treetagger__tests__fixed_tag_name.snap
+++ b/src/exporter/treetagger/snapshots/annatto__exporter__treetagger__tests__fixed_tag_name.snap
@@ -1,0 +1,24 @@
+---
+source: src/exporter/treetagger/tests.rs
+expression: export.unwrap()
+---
+---- doc1.tt:
+<doc author="&lt;unknown&gt;" year="1984">
+<mytagname something="annotated">
+Is	VBZ	be
+this	DT	this
+<mytagname anotherthing="annotated" evenmore="&lt;unknown-values&gt;">
+example	NN	example
+</mytagname>
+more	RBR	more
+</mytagname>
+complicated	JJ	complicated
+<mytagname>
+than	IN	than
+</mytagname>
+it	PP	it
+appears	VBZ	appear
+to	TO	to
+be	VB	be
+?	SENT	?
+</doc>

--- a/src/exporter/treetagger/snapshots/annatto__exporter__treetagger__tests__segmentation.snap
+++ b/src/exporter/treetagger/snapshots/annatto__exporter__treetagger__tests__segmentation.snap
@@ -1,0 +1,11 @@
+---
+source: src/exporter/treetagger/tests.rs
+expression: export.unwrap()
+---
+---- doc1.tt:
+<doc author="&lt;unknown&gt;" year="1984">
+An		
+other		
+example		
+text		
+</doc>

--- a/src/exporter/treetagger/snapshots/annatto__exporter__treetagger__tests__tag_name_from_anno_name.snap
+++ b/src/exporter/treetagger/snapshots/annatto__exporter__treetagger__tests__tag_name_from_anno_name.snap
@@ -1,0 +1,24 @@
+---
+source: src/exporter/treetagger/tests.rs
+expression: export.unwrap()
+---
+---- doc1.tt:
+<doc author="&lt;unknown&gt;" year="1984">
+<something something="annotated">
+Is	VBZ	be
+this	DT	this
+<anotherthing anotherthing="annotated" evenmore="&lt;unknown-values&gt;">
+example	NN	example
+</something>
+more	RBR	more
+</anotherthing>
+complicated	JJ	complicated
+<span>
+than	IN	than
+</span>
+it	PP	it
+appears	VBZ	appear
+to	TO	to
+be	VB	be
+?	SENT	?
+</doc>

--- a/src/exporter/treetagger/snapshots/annatto__exporter__treetagger__tests__tag_name_from_anno_namespace.snap
+++ b/src/exporter/treetagger/snapshots/annatto__exporter__treetagger__tests__tag_name_from_anno_namespace.snap
@@ -1,0 +1,24 @@
+---
+source: src/exporter/treetagger/tests.rs
+expression: export.unwrap()
+---
+---- doc1.tt:
+<doc author="&lt;unknown&gt;" year="1984">
+<default_ns something="annotated">
+Is	VBZ	be
+this	DT	this
+<default_ns anotherthing="annotated" evenmore="&lt;unknown-values&gt;">
+example	NN	example
+</default_ns>
+more	RBR	more
+</default_ns>
+complicated	JJ	complicated
+<span>
+than	IN	than
+</span>
+it	PP	it
+appears	VBZ	appear
+to	TO	to
+be	VB	be
+?	SENT	?
+</doc>

--- a/src/exporter/treetagger/tests.rs
+++ b/src/exporter/treetagger/tests.rs
@@ -1,0 +1,142 @@
+use graphannis::update::GraphUpdate;
+use insta::assert_snapshot;
+
+use super::*;
+use crate::{
+    test_util::export_to_string,
+    util::example_generator::{self, add_node_label, make_span},
+};
+
+fn create_test_corpus_base_token() -> AnnotationGraph {
+    let mut u = GraphUpdate::new();
+    example_generator::create_corpus_structure_simple(&mut u);
+    example_generator::create_tokens(&mut u, Some("root/doc1"));
+
+    // Add POS annotations
+    add_node_label(&mut u, "root/doc1#tok0", "default_ns", "pos", "VBZ");
+    add_node_label(&mut u, "root/doc1#tok1", "default_ns", "pos", "DT");
+    add_node_label(&mut u, "root/doc1#tok2", "default_ns", "pos", "NN");
+    add_node_label(&mut u, "root/doc1#tok3", "default_ns", "pos", "RBR");
+    add_node_label(&mut u, "root/doc1#tok4", "default_ns", "pos", "JJ");
+    add_node_label(&mut u, "root/doc1#tok5", "default_ns", "pos", "IN");
+    add_node_label(&mut u, "root/doc1#tok6", "default_ns", "pos", "PP");
+    add_node_label(&mut u, "root/doc1#tok7", "default_ns", "pos", "VBZ");
+    add_node_label(&mut u, "root/doc1#tok8", "default_ns", "pos", "TO");
+    add_node_label(&mut u, "root/doc1#tok9", "default_ns", "pos", "VB");
+    add_node_label(&mut u, "root/doc1#tok10", "default_ns", "pos", "SENT");
+
+    // Add lemma annotations
+    add_node_label(&mut u, "root/doc1#tok0", "default_ns", "lemma", "be");
+    add_node_label(&mut u, "root/doc1#tok1", "default_ns", "lemma", "this");
+    add_node_label(&mut u, "root/doc1#tok2", "default_ns", "lemma", "example");
+    add_node_label(&mut u, "root/doc1#tok3", "default_ns", "lemma", "more");
+    add_node_label(
+        &mut u,
+        "root/doc1#tok4",
+        "default_ns",
+        "lemma",
+        "complicated",
+    );
+    add_node_label(&mut u, "root/doc1#tok5", "default_ns", "lemma", "than");
+    add_node_label(&mut u, "root/doc1#tok6", "default_ns", "lemma", "it");
+    add_node_label(&mut u, "root/doc1#tok7", "default_ns", "lemma", "appear");
+    add_node_label(&mut u, "root/doc1#tok8", "default_ns", "lemma", "to");
+    add_node_label(&mut u, "root/doc1#tok9", "default_ns", "lemma", "be");
+    add_node_label(&mut u, "root/doc1#tok10", "default_ns", "lemma", "?");
+
+    // Add overlapping spans
+    make_span(
+        &mut u,
+        &"root/doc1#span1",
+        &["root/doc1#tok0", "root/doc1#tok1", "root/doc1#tok2"],
+        true,
+    );
+    add_node_label(
+        &mut u,
+        "root/doc1#span1",
+        "default_ns",
+        "something",
+        "annotated",
+    );
+    make_span(
+        &mut u,
+        &"root/doc1#span2",
+        &["root/doc1#tok2", "root/doc1#tok3"],
+        true,
+    );
+    add_node_label(
+        &mut u,
+        "root/doc1#span2",
+        "default_ns",
+        "anotherthing",
+        "annotated",
+    );
+    add_node_label(
+        &mut u,
+        "root/doc1#span2",
+        "default_ns",
+        "evenmore",
+        "<unknown-values>",
+    );
+
+    // Add some additional metadata to the document
+    add_node_label(&mut u, "root/doc1", "ignored", "author", "<unknown>");
+    add_node_label(&mut u, "root/doc1", "default_ns", "year", "1984");
+
+    let g = AnnotationGraph::with_default_graphstorages(true);
+    assert!(g.is_ok());
+    let mut graph = g.unwrap();
+    assert!(graph.apply_update(&mut u, |_| {}).is_ok());
+    graph
+}
+
+fn create_test_corpus_segmentations() -> AnnotationGraph {
+    let mut u = GraphUpdate::new();
+    example_generator::create_corpus_structure_simple(&mut u);
+    example_generator::create_multiple_segmentations(&mut u, "root/doc1");
+
+    // Add some additional metadata to the document
+    add_node_label(&mut u, "root/doc1", "ignored", "author", "<unknown>");
+    add_node_label(&mut u, "root/doc1", "default_ns", "year", "1984");
+
+    let g = AnnotationGraph::with_default_graphstorages(true);
+    assert!(g.is_ok());
+    let mut graph = g.unwrap();
+    assert!(graph.apply_update(&mut u, |_| {}).is_ok());
+    graph
+}
+
+#[test]
+fn core() {
+    let graph = create_test_corpus_base_token();
+
+    let export_config = ExportTreeTagger::default();
+
+    let export = export_to_string(&graph, export_config);
+    assert!(export.is_ok(), "error: {:?}", export.err());
+    assert_snapshot!(export.unwrap());
+}
+
+#[test]
+fn core_no_metadata() {
+    let graph = create_test_corpus_base_token();
+
+    let mut export_config = ExportTreeTagger::default();
+    export_config.skip_meta = true;
+
+    let export = export_to_string(&graph, export_config);
+    assert!(export.is_ok(), "error: {:?}", export.err());
+    assert_snapshot!(export.unwrap());
+}
+
+#[test]
+fn segmentation() {
+    let graph = create_test_corpus_segmentations();
+
+    let mut export_config = ExportTreeTagger::default();
+    export_config.segmentation = Some("b".to_string());
+
+    let export = export_to_string(&graph, export_config);
+    assert!(export.is_ok(), "error: {:?}", export.err());
+    assert_snapshot!(export.unwrap());
+}

--- a/src/exporter/treetagger/tests.rs
+++ b/src/exporter/treetagger/tests.rs
@@ -12,6 +12,8 @@ fn create_test_corpus_base_token() -> AnnotationGraph {
     example_generator::create_corpus_structure_simple(&mut u);
     example_generator::create_tokens(&mut u, Some("root/doc1"));
 
+    add_node_label(&mut u, "root", "", "corpus-name", "root");
+
     // Add POS annotations
     add_node_label(&mut u, "root/doc1#tok0", "default_ns", "pos", "VBZ");
     add_node_label(&mut u, "root/doc1#tok1", "default_ns", "pos", "DT");
@@ -113,6 +115,17 @@ fn core() {
     let graph = create_test_corpus_base_token();
 
     let export_config: ExportTreeTagger = toml::from_str("").unwrap();
+
+    let export = export_to_string(&graph, export_config);
+    assert!(export.is_ok(), "error: {:?}", export.err());
+    assert_snapshot!(export.unwrap());
+}
+
+#[test]
+fn core_different_doc_name() {
+    let graph = create_test_corpus_base_token();
+
+    let export_config: ExportTreeTagger = toml::from_str(r#"doc_anno = "corpus-name""#).unwrap();
 
     let export = export_to_string(&graph, export_config);
     assert!(export.is_ok(), "error: {:?}", export.err());

--- a/src/exporter/treetagger/tests.rs
+++ b/src/exporter/treetagger/tests.rs
@@ -78,6 +78,8 @@ fn create_test_corpus_base_token() -> AnnotationGraph {
         "evenmore",
         "<unknown-values>",
     );
+    // Span without a label
+    make_span(&mut u, &"root/doc1#span3", &["root/doc1#tok5"], true);
 
     // Add some additional metadata to the document
     add_node_label(&mut u, "root/doc1", "ignored", "author", "<unknown>");
@@ -123,6 +125,18 @@ fn core_no_metadata() {
 
     let mut export_config = ExportTreeTagger::default();
     export_config.skip_meta = true;
+
+    let export = export_to_string(&graph, export_config);
+    assert!(export.is_ok(), "error: {:?}", export.err());
+    assert_snapshot!(export.unwrap());
+}
+
+#[test]
+fn core_no_spans() {
+    let graph = create_test_corpus_base_token();
+
+    let mut export_config = ExportTreeTagger::default();
+    export_config.skip_spans = true;
 
     let export = export_to_string(&graph, export_config);
     assert!(export.is_ok(), "error: {:?}", export.err());

--- a/src/exporter/treetagger/tests.rs
+++ b/src/exporter/treetagger/tests.rs
@@ -112,7 +112,7 @@ fn create_test_corpus_segmentations() -> AnnotationGraph {
 fn core() {
     let graph = create_test_corpus_base_token();
 
-    let export_config = ExportTreeTagger::default();
+    let export_config: ExportTreeTagger = toml::from_str("").unwrap();
 
     let export = export_to_string(&graph, export_config);
     assert!(export.is_ok(), "error: {:?}", export.err());
@@ -123,8 +123,7 @@ fn core() {
 fn core_no_metadata() {
     let graph = create_test_corpus_base_token();
 
-    let mut export_config = ExportTreeTagger::default();
-    export_config.skip_meta = true;
+    let export_config: ExportTreeTagger = toml::from_str(r#"skip_meta = true"#).unwrap();
 
     let export = export_to_string(&graph, export_config);
     assert!(export.is_ok(), "error: {:?}", export.err());
@@ -135,8 +134,55 @@ fn core_no_metadata() {
 fn core_no_spans() {
     let graph = create_test_corpus_base_token();
 
-    let mut export_config = ExportTreeTagger::default();
-    export_config.skip_spans = true;
+    let export_config: ExportTreeTagger = toml::from_str(r#"skip_spans = true"#).unwrap();
+
+    let export = export_to_string(&graph, export_config);
+    assert!(export.is_ok(), "error: {:?}", export.err());
+    assert_snapshot!(export.unwrap());
+}
+
+#[test]
+fn fixed_tag_name() {
+    let graph = create_test_corpus_base_token();
+
+    let export_config: ExportTreeTagger = toml::from_str(
+        r#"
+        span_names = { strategy = "fixed", name = "mytagname"}
+        "#,
+    )
+    .unwrap();
+
+    let export = export_to_string(&graph, export_config);
+    assert!(export.is_ok(), "error: {:?}", export.err());
+    assert_snapshot!(export.unwrap());
+}
+
+#[test]
+fn tag_name_from_anno_name() {
+    let graph = create_test_corpus_base_token();
+
+    let export_config: ExportTreeTagger = toml::from_str(
+        r#"
+        span_names = { strategy = "first_anno_name"}
+        "#,
+    )
+    .unwrap();
+
+    let export = export_to_string(&graph, export_config);
+    assert!(export.is_ok(), "error: {:?}", export.err());
+    assert_snapshot!(export.unwrap());
+}
+
+#[test]
+fn tag_name_from_anno_namespace() {
+    let graph = create_test_corpus_base_token();
+
+    let export_config: ExportTreeTagger = toml::from_str(
+        r#"
+        span_names = { strategy = "first_anno_namespace"}
+        "#,
+    )
+    .unwrap();
 
     let export = export_to_string(&graph, export_config);
     assert!(export.is_ok(), "error: {:?}", export.err());

--- a/src/importer/relannis.rs
+++ b/src/importer/relannis.rs
@@ -850,18 +850,17 @@ fn calculate_automatic_coverage_edges(
                 .textpos_table
                 .token_to_index
                 .contains_key(&n)?
-        {
-            if let Err(e) = add_automatic_cov_edge_for_node(
+            && let Err(e) = add_automatic_cov_edge_for_node(
                 updates,
                 n,
                 load_node_and_corpus_result,
                 load_rank_result,
-            ) {
-                // output a warning but do not fail
-                progress.warn(&format!(
-                    "Adding coverage edges (connects spans with tokens) failed: {e}"
-                ))?;
-            }
+            )
+        {
+            // output a warning but do not fail
+            progress.warn(&format!(
+                "Adding coverage edges (connects spans with tokens) failed: {e}"
+            ))?;
         } // end if not a token
     }
 

--- a/src/importer/textgrid.rs
+++ b/src/importer/textgrid.rs
@@ -193,10 +193,10 @@ impl DocumentMapper<'_> {
                 Some(current_pot.0)
             };
             let mut end = None;
-            if !self.params.skip_time_annotations {
-                if let Some(next_pot) = it.peek() {
-                    end = Some(next_pot.0);
-                }
+            if !self.params.skip_time_annotations
+                && let Some(next_pot) = it.peek()
+            {
+                end = Some(next_pot.0);
             }
             let tli_id = map_token(
                 u,
@@ -233,15 +233,14 @@ impl DocumentMapper<'_> {
                 if let TextGridItem::Interval {
                     name, intervals, ..
                 } = tier
+                    && name == token_tier_name
                 {
-                    if name == token_tier_name {
-                        for i in intervals {
-                            if !i.text.trim().is_empty() {
-                                token_sorted_by_time.insert(
-                                    (OrderedFloat(i.xmin), OrderedFloat(i.xmax)),
-                                    i.text.clone(),
-                                );
-                            }
+                    for i in intervals {
+                        if !i.text.trim().is_empty() {
+                            token_sorted_by_time.insert(
+                                (OrderedFloat(i.xmin), OrderedFloat(i.xmax)),
+                                i.text.clone(),
+                            );
                         }
                     }
                 }
@@ -269,9 +268,9 @@ impl DocumentMapper<'_> {
 
             Ok(result)
         } else {
-            return Err(anyhow!(
+            Err(anyhow!(
                 "Exactly one token tier must be definied in tier_groups when mapping without a timeline (map_timeline=false"
-            ));
+            ))
         }
     }
 

--- a/src/importer/treetagger.rs
+++ b/src/importer/treetagger.rs
@@ -232,70 +232,70 @@ impl<'a> DocumentMapper<'a> {
         is_last_line: bool,
     ) -> anyhow::Result<()> {
         // Get the tag name and the nearest matching tag from stack
-        if let Some(tag_name) = end_tag.next() {
-            if tag_name.as_rule() == Rule::tag_name {
-                let tag_name = tag_name.as_str();
+        if let Some(tag_name) = end_tag.next()
+            && tag_name.as_rule() == Rule::tag_name
+        {
+            let tag_name = tag_name.as_str();
 
-                if let Some(idx) = self.tag_stack.iter().position(|t| t.anno_name == tag_name) {
-                    let entry = self.tag_stack.remove(idx);
+            if let Some(idx) = self.tag_stack.iter().position(|t| t.anno_name == tag_name) {
+                let entry = self.tag_stack.remove(idx);
 
-                    let is_meta = entry.was_first_line && is_last_line;
+                let is_meta = entry.was_first_line && is_last_line;
 
-                    let node_id = if is_meta {
-                        // This is a meta annotation for the whole document
-                        self.doc_path.clone()
-                    } else {
-                        // Add a node update for the new span
-                        self.number_of_spans += 1;
-                        let span_id = format!("{}#span{}", self.doc_path, self.number_of_spans);
-                        u.add_event(UpdateEvent::AddNode {
-                            node_name: span_id.clone(),
-                            node_type: "node".into(),
-                        })?;
-                        // TODO: support namespaces in span annotation name
-                        u.add_event(UpdateEvent::AddNodeLabel {
-                            node_name: span_id.clone(),
-                            anno_ns: "".into(),
-                            anno_name: tag_name.into(),
-                            anno_value: tag_name.into(),
-                        })?;
+                let node_id = if is_meta {
+                    // This is a meta annotation for the whole document
+                    self.doc_path.clone()
+                } else {
+                    // Add a node update for the new span
+                    self.number_of_spans += 1;
+                    let span_id = format!("{}#span{}", self.doc_path, self.number_of_spans);
+                    u.add_event(UpdateEvent::AddNode {
+                        node_name: span_id.clone(),
+                        node_type: "node".into(),
+                    })?;
+                    // TODO: support namespaces in span annotation name
+                    u.add_event(UpdateEvent::AddNodeLabel {
+                        node_name: span_id.clone(),
+                        anno_ns: "".into(),
+                        anno_name: tag_name.into(),
+                        anno_value: tag_name.into(),
+                    })?;
 
-                        u.add_event(UpdateEvent::AddNodeLabel {
-                            node_name: span_id.clone(),
-                            anno_ns: ANNIS_NS.to_string(),
-                            anno_name: "layer".to_string(),
-                            anno_value: "default_layer".to_string(),
-                        })?;
-                        // Add coverage edges for all covered token
-                        for t in entry.covered_token {
-                            u.add_event(UpdateEvent::AddEdge {
-                                source_node: span_id.clone(),
-                                target_node: t,
-                                layer: ANNIS_NS.into(),
-                                component_type: "Coverage".into(),
-                                component_name: "".into(),
-                            })?;
-                        }
-                        span_id
-                    };
-
-                    // Add all attributes as node annotations
-                    for (anno_name, anno_value) in entry.attributes {
-                        // TODO: allow to configure not to prepend the tag name to the annotation
-
-                        let anno_name = if is_meta {
-                            anno_name
-                        } else {
-                            format!("{tag_name}_{anno_name}")
-                        };
-                        // TODO: support namespaces as annotation names
-                        u.add_event(UpdateEvent::AddNodeLabel {
-                            node_name: node_id.clone(),
-                            anno_ns: "".into(),
-                            anno_name,
-                            anno_value,
+                    u.add_event(UpdateEvent::AddNodeLabel {
+                        node_name: span_id.clone(),
+                        anno_ns: ANNIS_NS.to_string(),
+                        anno_name: "layer".to_string(),
+                        anno_value: "default_layer".to_string(),
+                    })?;
+                    // Add coverage edges for all covered token
+                    for t in entry.covered_token {
+                        u.add_event(UpdateEvent::AddEdge {
+                            source_node: span_id.clone(),
+                            target_node: t,
+                            layer: ANNIS_NS.into(),
+                            component_type: "Coverage".into(),
+                            component_name: "".into(),
                         })?;
                     }
+                    span_id
+                };
+
+                // Add all attributes as node annotations
+                for (anno_name, anno_value) in entry.attributes {
+                    // TODO: allow to configure not to prepend the tag name to the annotation
+
+                    let anno_name = if is_meta {
+                        anno_name
+                    } else {
+                        format!("{tag_name}_{anno_name}")
+                    };
+                    // TODO: support namespaces as annotation names
+                    u.add_event(UpdateEvent::AddNodeLabel {
+                        node_name: node_id.clone(),
+                        anno_ns: "".into(),
+                        anno_name,
+                        anno_value,
+                    })?;
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ use strum::{AsRefStr, EnumDiscriminants, EnumIter};
 use tabled::Tabled;
 use workflow::StatusSender;
 
-use crate::importer::git::ImportGitMetadata;
+use crate::{exporter::treetagger::ExportTreeTagger, importer::git::ImportGitMetadata};
 
 #[derive(Tabled)]
 pub struct ModuleConfiguration {
@@ -66,6 +66,7 @@ pub enum WriteAs {
     Sequence(#[serde(default)] ExportSequence),
     Table(#[serde(default)] ExportTable),
     TextGrid(ExportTextGrid), // do not use default, as all attributes have their individual defaults
+    TreeTagger(#[serde(default)] ExportTreeTagger),
     Xlsx(#[serde(default)] ExportXlsx),
 }
 
@@ -85,6 +86,7 @@ impl WriteAs {
             WriteAs::Sequence(m) => m,
             WriteAs::Table(m) => m,
             WriteAs::TextGrid(m) => m,
+            WriteAs::TreeTagger(m) => m,
             WriteAs::Xlsx(m) => m,
             WriteAs::CoNLLU(m) => &**m,
             WriteAs::Meta(m) => m,
@@ -101,6 +103,7 @@ impl WriteAsDiscriminants {
             WriteAsDiscriminants::Sequence => ExportSequence::DOCS,
             WriteAsDiscriminants::Table => ExportTable::DOCS,
             WriteAsDiscriminants::TextGrid => ExportTextGrid::DOCS,
+            WriteAsDiscriminants::TreeTagger => ExportTreeTagger::DOCS,
             WriteAsDiscriminants::Xlsx => ExportXlsx::DOCS,
             WriteAsDiscriminants::CoNLLU => ExportCoNLLU::DOCS,
             WriteAsDiscriminants::Meta => ExportMeta::DOCS,
@@ -132,6 +135,10 @@ impl WriteAsDiscriminants {
             WriteAsDiscriminants::TextGrid => (
                 ExportTextGrid::FIELD_NAMES_AS_SLICE,
                 ExportTextGrid::FIELD_DOCS,
+            ),
+            WriteAsDiscriminants::TreeTagger => (
+                ExportTreeTagger::FIELD_NAMES_AS_SLICE,
+                ExportTreeTagger::FIELD_DOCS,
             ),
             WriteAsDiscriminants::Xlsx => {
                 (ExportXlsx::FIELD_NAMES_AS_SLICE, ExportXlsx::FIELD_DOCS)

--- a/src/manipulator/collapse.rs
+++ b/src/manipulator/collapse.rs
@@ -358,19 +358,17 @@ impl Collapse {
         if let Some(component_storage) = graph.get_graphstorage(&self.component) {
             for key in node_annos.get_all_keys_for_item(from_node, None, None)? {
                 // only transfer `annis::` annotations for terminal nodes of the component and never transfer the node name key
-                if key.ns.as_str() != ANNIS_NS
-                    || !component_storage.has_outgoing_edges(*from_node)? && key != *NODE_NAME_KEY
-                {
-                    if let Some(anno_value) =
+                if (key.ns.as_str() != ANNIS_NS
+                    || !component_storage.has_outgoing_edges(*from_node)? && key != *NODE_NAME_KEY)
+                    && let Some(anno_value) =
                         node_annos.get_value_for_item(from_node, key.as_ref())?
-                    {
-                        update.add_event(UpdateEvent::AddNodeLabel {
-                            node_name: to_node.to_string(),
-                            anno_ns: key.ns.to_string(),
-                            anno_name: key.name.to_string(),
-                            anno_value: anno_value.to_string(),
-                        })?;
-                    }
+                {
+                    update.add_event(UpdateEvent::AddNodeLabel {
+                        node_name: to_node.to_string(),
+                        anno_ns: key.ns.to_string(),
+                        anno_name: key.name.to_string(),
+                        anno_value: anno_value.to_string(),
+                    })?;
                 }
             }
             Ok(())

--- a/src/manipulator/enumerate.rs
+++ b/src/manipulator/enumerate.rs
@@ -259,11 +259,11 @@ impl Manipulator for EnumerateMatches {
                                         .get_value_for_item(&internal_id, &coord_anno_key)?
                                         .unwrap_or_default()
                                         .to_string();
-                                    if let Some(previous_value) = by_values.get(bi) {
-                                        if &next_value != previous_value {
-                                            // reset count
-                                            reset_count = true;
-                                        }
+                                    if let Some(previous_value) = by_values.get(bi)
+                                        && &next_value != previous_value
+                                    {
+                                        // reset count
+                                        reset_count = true;
                                     }
                                     by_values.insert(bi, next_value);
                                 }

--- a/src/util/example_generator.rs
+++ b/src/util/example_generator.rs
@@ -9,7 +9,7 @@ use graphannis_core::graph::{
 /// ```
 ///     root
 ///       |
-///      docc1
+///     docc1
 /// ```
 pub fn create_corpus_structure_simple(update: &mut GraphUpdate) {
     update
@@ -169,18 +169,18 @@ pub fn create_corpus_structure_two_documents(update: &mut GraphUpdate) {
 /// token objects are attached to it.
 ///
 /// The example tokens are
-/// - Is (`tok1`)
-/// - this (`tok2`)
-/// - example (`tok3`)
-/// - more (`tok4`)
-/// - complicated (`tok5`)
-/// - than (`tok6`)
-/// - it (`tok7`)
-/// - appears (`tok8`)
-/// - to (`tok9`)
-/// - be (`tok10`)
-/// - ? (`tok11`)
-///  
+/// - Is (`tok0`)
+/// - this (`tok1`)
+/// - example (`tok2`)
+/// - more (`tok3`)
+/// - complicated (`tok4`)
+/// - than (`tok5`)
+/// - it (`tok6`)
+/// - appears (`tok7`)
+/// - to (`tok8`)
+/// - be (`tok9`)
+/// - ? (`tok10`)
+///
 pub fn create_tokens(update: &mut GraphUpdate, document_node: Option<&str>) {
     let prefix = if let Some(document_node) = document_node {
         format!("{}#", document_node)

--- a/src/util/example_generator.rs
+++ b/src/util/example_generator.rs
@@ -492,3 +492,20 @@ pub fn make_segmentation_span(
         })
         .unwrap();
 }
+
+pub fn add_node_label(
+    update: &mut GraphUpdate,
+    node_name: &str,
+    ns: &str,
+    name: &str,
+    value: &str,
+) {
+    update
+        .add_event(UpdateEvent::AddNodeLabel {
+            node_name: node_name.into(),
+            anno_ns: ns.into(),
+            anno_name: name.into(),
+            anno_value: value.into(),
+        })
+        .unwrap()
+}

--- a/src/util/example_generator.rs
+++ b/src/util/example_generator.rs
@@ -234,7 +234,8 @@ pub fn create_tokens(update: &mut GraphUpdate, document_node: Option<&str>) {
 /// b: [An] [other] [example   ] [text]
 /// ```
 ///
-/// The timeline items have the name `tli1`, `tli2`, ..., `tli5`.
+/// The timeline items have the names `tli1`, `tli2`, ..., `tli5` and the
+/// segmentation token have the names `a1`, `b1`, `a2`, ...
 pub(crate) fn create_multiple_segmentations(update: &mut GraphUpdate, document_node: &str) {
     let prefix = format!("{}#", document_node);
 

--- a/tests/snapshots/cli__list_modules.snap
+++ b/tests/snapshots/cli__list_modules.snap
@@ -5,7 +5,7 @@ expression: output
 | Type             | Modules                                                                                                                                            |
 |------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
 | Import formats   | conllu, exmaralda, git, graphml, meta, none, opus, path, ptb, relannis, saltxml, table, textgrid, toolbox, treetagger, webanno, whisper, xlsx, xml |
-| Export formats   | conllu, exmaralda, graphml, meta, saltxml, sequence, table, textgrid, xlsx                                                                         |
+| Export formats   | conllu, exmaralda, graphml, meta, saltxml, sequence, table, textgrid, treetagger, xlsx                                                             |
 | Graph operations | align, check, collapse, filter, visualize, enumerate, link, map, revise, time, chunk, split, sleep, none                                           |
 
 Use `annatto info <name>` to get more information about one of the formats or graph operations.


### PR DESCRIPTION
Adds a new exporter for the TreeTagger format that supports exporting spans and metadata as SGML tags.